### PR TITLE
Remove libstdc++ from prereqs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,18 +30,13 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          # - oracle12cR1-centos-7
-          # - oracle12cR2-centos-7
+          - websphere-v90-centos-8
+          - db21157        
           - oracle19c-centos-8
           - iim-191-centos-8
           - ihs-v90-centos-8
-          # - ihs-v80-centos-7
-          # - ohs-v12.2.1-centos-7
           - ohs-v12.2.1-centos-8
-          # - ohs-v12.1.3-centos-7
-          # - liberty-centos-7
           - liberty-centos-8
-          # - weblogic-centos-7
           - weblogic-centos-8
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         scenario:
           - websphere-v90-centos-8
-          - db21157        
+          - db21157
           - oracle19c-centos-8
           - iim-191-centos-8
           - ihs-v90-centos-8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,19 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - websphere-v90-centos-8
-          # - websphere-v85-centos-7
-          - db21146
-          - db21157
+          # - oracle12cR1-centos-7
+          # - oracle12cR2-centos-7
+          - oracle19c-centos-8
+          - iim-191-centos-8
+          - ihs-v90-centos-8
+          # - ihs-v80-centos-7
+          # - ohs-v12.2.1-centos-7
+          - ohs-v12.2.1-centos-8
+          # - ohs-v12.1.3-centos-7
+          # - liberty-centos-7
+          - liberty-centos-8
+          # - weblogic-centos-7
+          - weblogic-centos-8
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,19 +34,6 @@ jobs:
           # - websphere-v85-centos-7
           - db21146
           - db21157
-          # - oracle12cR1-centos-7
-          # - oracle12cR2-centos-7
-          - oracle19c-centos-8
-          - iim-191-centos-8
-          - ihs-v90-centos-8
-          # - ihs-v80-centos-7
-          # - ohs-v12.2.1-centos-7
-          - ohs-v12.2.1-centos-8
-          # - ohs-v12.1.3-centos-7
-          # - liberty-centos-7
-          - liberty-centos-8
-          # - weblogic-centos-7
-          - weblogic-centos-8
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.2.1
+version: 1.2.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/db2/tasks/prereqs.yml
+++ b/roles/db2/tasks/prereqs.yml
@@ -19,7 +19,6 @@
       - kernel-devel
       - ksh
       - libaio
-      - libstdc++
       - make
       - numactl-libs
       - pam-devel


### PR DESCRIPTION
`libstdc++` installed as dependency of `gcc-c++`

`gcc-c++` installs an older `libstdc++` version, newer version is not compatible with `gcc-c++` which is required for db2 installation