### PR TITLE
Change the appserver passwords to plaintext

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.2.4
+version: 1.2.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/liberty/files/AppServer.properties
+++ b/roles/liberty/files/AppServer.properties
@@ -8,8 +8,7 @@ as.vendor=WLP
 # The username and password for admin server.
 security.username=websphere
 # Encrypt the plain-text password using 'build encrypt -Dpassword=<password>'
-# Below is the encryption for the default password ("websphere")
-security.password=XOVRjjVTebM8gV953LGMLQ==
+security.password=websphere
 
 # The name of the WebSphere Node or WebLogic Domain Name.
 node.name=liberty

--- a/roles/weblogic/defaults/main.yml
+++ b/roles/weblogic/defaults/main.yml
@@ -14,7 +14,7 @@ applications_home: '{{ weblogic_base }}/config/applications'
 mw_installer_folder: '{{ weblogic_base }}/installer'
 domain_username: 'weblogic'
 domain_password: 'weblogic'
-encrypted_password: 'dummypassword'
+encrypted_password: 'weblogic1'
 server_name: 'CuramServer'
 server_port: 7001
 

--- a/roles/websphere/templates/AppServer.properties.j2
+++ b/roles/websphere/templates/AppServer.properties.j2
@@ -10,7 +10,7 @@ security.username=websphere
 # Encrypt the plain-text password using 'build encrypt -Dpassword=<password>'
 # Below is the encryption for the default password ("websphere").
 # NOTE: This must be updated after your first login!
-security.password=XOVRjjVTebM8gV953LGMLQ==
+security.password=websphere
 
 # The name of the WebSphere Node or WebLogic Domain Name.
 node.name={{ansible_hostname}}

--- a/roles/websphere/templates/AppServer.properties.j2
+++ b/roles/websphere/templates/AppServer.properties.j2
@@ -8,7 +8,6 @@ as.vendor=IBM
 # The username and password for admin server.
 security.username=websphere
 # Encrypt the plain-text password using 'build encrypt -Dpassword=<password>'
-# Below is the encryption for the default password ("websphere").
 # NOTE: This must be updated after your first login!
 security.password=websphere
 


### PR DESCRIPTION
## Summary:

These changes will be merged along with the changes to spm_deployment to use plaintext passwords for websphere/weblogic/liberty that will then be encrypted on the fly during deployment (rather than starting with an encrypted password that is always encrypted the same). The reason is that shipping the same encrypted pass always was considered a vulnerability.

## Testing:

See ticket