### PR TITLE
Java heap

### DIFF
--- a/molecule/__websphere-v90/verify.yml
+++ b/molecule/__websphere-v90/verify.yml
@@ -29,7 +29,7 @@
     - name: Check that JspBatchCompiler has been patched
       assert:
         that:
-          - "{{ '-Xmx1600m' in (jsp_compiler_sh['content'] | b64decode) }}"
+          - "{{ '-Xmx2000m' in (jsp_compiler_sh['content'] | b64decode) }}"
 
     - name: Check that environment file has been created correctly
       assert:

--- a/roles/websphere/tasks/configure.yml
+++ b/roles/websphere/tasks/configure.yml
@@ -3,5 +3,5 @@
   replace:
     path: "{{ websphere_install_path }}/bin/JspBatchCompiler.sh"
     regexp: "-Xmx256m"
-    replace: "-Xmx1600m"
+    replace: "-Xmx2000m"
     mode: 0755


### PR DESCRIPTION
Our createReleaseZip job: https://spmdevops.jenkins.commops.merative.com/job/DevOps-CreateReleaseZip/ has stopped working for v81IncomeSupport and other configs when kicked off by CI_main.

They are all failing with a java out of memory: heap space issue.