### PR TITLE
ensure /opt/Props/ exists

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.3.0
+version: 1.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ihs/tasks/main.yml
+++ b/roles/ihs/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure /opt/Props dir exists
+  file:
+    path: /opt/Props
+    state: directory
+
 - name: Include version variables
   include_vars: "v{{ ihs_version }}.yml"
 


### PR DESCRIPTION
/opt/Props is not created when install IHS seperately.
Never seen this until we want to deploy cluster and want seperate IHS server.