### PR TITLE
move java installer for ohs/IHS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,4 +88,4 @@ jobs:
         run: |
           cd ${{ env.NEW_REPO_LOC }}
           ls -la
-          molecule test -s ${{ matrix.scenario }}
+          molecule test -s ${{ matrix.scenario }} -vvv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,4 +88,4 @@ jobs:
         run: |
           cd ${{ env.NEW_REPO_LOC }}
           ls -la
-          molecule test -s ${{ matrix.scenario }} -vvv
+          molecule -vvv test -s ${{ matrix.scenario }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,4 +88,4 @@ jobs:
         run: |
           cd ${{ env.NEW_REPO_LOC }}
           ls -la
-          molecule -vvv test -s ${{ matrix.scenario }}
+          molecule test -s ${{ matrix.scenario }}

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.4.0
+version: 1.4.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/iim/tasks/centos.yml
+++ b/roles/iim/tasks/centos.yml
@@ -18,4 +18,4 @@
 
 - name: Linux common
   include_tasks:
-      file: "linux_common.yml"
+    file: "linux_common.yml"

--- a/roles/iim/tasks/centos.yml
+++ b/roles/iim/tasks/centos.yml
@@ -17,6 +17,5 @@
   when: (ansible_distribution_major_version | int) == 7
 
 - name: Linux common
-  # include: "linux_common.yml"
   include_tasks:
       file: "linux_common.yml"

--- a/roles/iim/tasks/centos.yml
+++ b/roles/iim/tasks/centos.yml
@@ -17,4 +17,6 @@
   when: (ansible_distribution_major_version | int) == 7
 
 - name: Linux common
-  include: "linux_common.yml"
+  # include: "linux_common.yml"
+  include_tasks:
+      file: "linux_common.yml"

--- a/roles/iim/tasks/debian.yml
+++ b/roles/iim/tasks/debian.yml
@@ -6,4 +6,6 @@
     state: present
 
 - name: Linux common
-  include: "linux_common.yml"
+  # include: "linux_common.yml"
+  include_tasks:
+    file: "linux_common.yml"

--- a/roles/iim/tasks/debian.yml
+++ b/roles/iim/tasks/debian.yml
@@ -6,6 +6,5 @@
     state: present
 
 - name: Linux common
-  # include: "linux_common.yml"
   include_tasks:
     file: "linux_common.yml"

--- a/roles/iim/tasks/main.yml
+++ b/roles/iim/tasks/main.yml
@@ -15,5 +15,7 @@
   when: ansible_os_family == "Windows"
 
 - name: Install IIM
-  include: "{{ ansible_os_family | lower }}.yml"
+  # include: "{{ ansible_os_family | lower }}.yml"
+  include_tasks:
+        file: "{{ ansible_os_family | lower }}.yml"
   when: (linux_iim_dir.stat is defined and not linux_iim_dir.stat.exists) or (win_iim_dir.stat is defined and not win_iim_dir.stat.exists)

--- a/roles/iim/tasks/main.yml
+++ b/roles/iim/tasks/main.yml
@@ -16,5 +16,5 @@
 
 - name: Install IIM
   include_tasks:
-        file: "{{ ansible_os_family | lower }}.yml"
+    file: "{{ ansible_os_family | lower }}.yml"
   when: (linux_iim_dir.stat is defined and not linux_iim_dir.stat.exists) or (win_iim_dir.stat is defined and not win_iim_dir.stat.exists)

--- a/roles/iim/tasks/main.yml
+++ b/roles/iim/tasks/main.yml
@@ -15,7 +15,6 @@
   when: ansible_os_family == "Windows"
 
 - name: Install IIM
-  # include: "{{ ansible_os_family | lower }}.yml"
   include_tasks:
         file: "{{ ansible_os_family | lower }}.yml"
   when: (linux_iim_dir.stat is defined and not linux_iim_dir.stat.exists) or (win_iim_dir.stat is defined and not win_iim_dir.stat.exists)

--- a/roles/iim/tasks/redhat.yml
+++ b/roles/iim/tasks/redhat.yml
@@ -16,6 +16,4 @@
   when: (ansible_distribution_major_version | int) == 7
 
 - name: Linux common
-  # include: "linux_common.yml"
-  include_tasks:
       file: "linux_common.yml"

--- a/roles/iim/tasks/redhat.yml
+++ b/roles/iim/tasks/redhat.yml
@@ -16,4 +16,6 @@
   when: (ansible_distribution_major_version | int) == 7
 
 - name: Linux common
-  include: "linux_common.yml"
+  # include: "linux_common.yml"
+  include_tasks:
+      file: "linux_common.yml"

--- a/roles/iim/tasks/redhat.yml
+++ b/roles/iim/tasks/redhat.yml
@@ -16,4 +16,5 @@
   when: (ansible_distribution_major_version | int) == 7
 
 - name: Linux common
-      file: "linux_common.yml"
+  include_tasks:
+    file: "linux_common.yml"

--- a/roles/ohs/vars/v12.1.3.0.200412.yml
+++ b/roles/ohs/vars/v12.1.3.0.200412.yml
@@ -15,7 +15,7 @@ opatch_version: 13.9.4.2.6
 opatch_folder: 6880880
 
 # Full jdk is needed to update OPatch
-java_zip_path: 'Java/jdk-8u251-linux-x64.tar.gz'
+java_zip_path: 'WLS/jdk-8u251-linux-x64.tar.gz'
 java_version_path: 'jdk1.8.0_251'
 jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
 

--- a/roles/ohs/vars/v12.2.1.4.210324.yml
+++ b/roles/ohs/vars/v12.2.1.4.210324.yml
@@ -17,7 +17,7 @@ opatch_version: 13.9.4.2.6
 opatch_folder: 6880880
 
 # Full jdk is needed to update OPatch
-java_zip_path: 'Java/jdk-8u251-linux-x64.tar.gz'
+java_zip_path: 'WLS/jdk-8u251-linux-x64.tar.gz'
 java_version_path: 'jdk1.8.0_251'
 jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
 

--- a/roles/weblogic/defaults/main.yml
+++ b/roles/weblogic/defaults/main.yml
@@ -27,4 +27,4 @@ weblogic_installer_path: WLS
 # Local controller path relative to weblogic_installer_path OR relative path to download_url/weblogic_installer_path
 weblogic_patch_path: Patches
 # Local controller path OR relative path to download_url
-java_zip_path: 'Java'
+java_zip_path: 'WLS'


### PR DESCRIPTION
## Story:
https://github.com/merative/spm-middleware/tree/moveJDK

Per the story we need to move the  java JDKs used by ohs and weblogic to the WLS folder (both, confirmed by sian). This PR is to point our collection at the new location.

## Changes
1) Point collection at new JDK location and increment galaxy version to publish collection
2) Remove includes module as this is failing our molecule with a deprecation error.
## Testing

Ran molecule tests in devenv as instructed here:
https://galaxy.ansible.com/ui/repo/published/merative/spm_middleware/docs/
Also GH actions will do the same for this PR.