### PR TITLE
Websphere/ihs 90518

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.4.3
+version: 1.4.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ihs-v90/converge.yml
+++ b/molecule/__ihs-v90/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 9.0.5.17
+    ihs_version: 9.0.5.18
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v90/converge.yml
+++ b/molecule/__websphere-v90/converge.yml
@@ -6,9 +6,9 @@
     - merative.spm_middleware
 
   vars:
-    iim_agent_version: 1.9.2005.20230718_1844
+    iim_agent_version: 1.9.2006.20230925_1323
     iim_install_path: /opt/IBM/InstallationManager
-    websphere_version: 9.0.5.17
+    websphere_version: 9.0.5.18
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/iim-191-rockylinux8/converge.yml
+++ b/molecule/iim-191-rockylinux8/converge.yml
@@ -9,6 +9,6 @@
     - iim
 
   vars:
-    iim_agent_version: 1.9.2005.20230718_1844
+    iim_agent_version: 1.9.2006.20230925_1323
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/roles/ihs/README.md
+++ b/roles/ihs/README.md
@@ -13,18 +13,18 @@ NOTE: ihs_admin_pass should be changed after first installation.
 | `ihs_install_path`      | `/opt/IBM/HTTPServer`                               |
 | `plg_install_path`      | `/opt/IBM/WebSphere/Plugins`                        |
 | `wct_install_path`      | `/opt/IBM/WebSphere/Toolbox`                        |
-| `ihs_version`           | `9.0.5.17`                                           |
+| `ihs_version`           | `9.0.5.18`                                           |
 | `ihs_config_type`       | `local_distributed`                                 |
 | `ihs_admin_user`        | `wasadmin`                                          |
 | `ihs_admin_pass`        | `wasadmin`                                          |
 | ----------------------- | --------------------------------------------------- |
-| Version-specific:       | Values from `9.0.5.17`                               |
+| Version-specific:       | Values from `9.0.5.18`                               |
 | ----------------------- | --------------------------------------------------- |
 | `ihs_installer_archive_list` | `was.repo.90500.[ihs|plugins|wct].zip`         |
-| `ihs_fp_installer_path` | `WAS/9.0.17Fixpacks`                                 |
-| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP008.zip` |
-| `ihs_pid`               | `v90_9.0.5017.20230818_1035`                        |
-| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.10-linux-x64-installmgr.zip` |
+| `ihs_fp_installer_path` | `WAS/9.0.5Fixpacks`                                 |
+| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP018.zip`           |
+| `ihs_pid`               | `v90_9.0.5018.20231113_1345`                        |
+| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip` |
 | `ihs_java_pid`          | `com.ibm.java.jdk.v8`                               |
 | ----------------------- | --------------------------------------------------- |
 | `iim_install_path`      | `/opt/IBM/InstallationManager`                      |
@@ -53,7 +53,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware.iim
     - merative.spm_middleware.ihs
       vars:
-        - ihs_version: 8.5.5.17
+        - ihs_version: 9.0.5.18
         - download_url: "https://myserver.com/IHS/repos"
         - download_header: { 'Authorization': 'Basic EncodedString'}
 ```

--- a/roles/ihs/defaults/main.yml
+++ b/roles/ihs/defaults/main.yml
@@ -5,7 +5,7 @@ ihs_install_path: /opt/IBM/HTTPServer
 plg_install_path: /opt/IBM/WebSphere/Plugins
 wct_install_path: /opt/IBM/WebSphere/Toolbox
 
-ihs_version: 9.0.5.17
+ihs_version: 9.0.5.18
 
 ihs_config_type: local_distributed
 ihs_admin_user: wasadmin

--- a/roles/ihs/vars/v9.0.5.18.yml
+++ b/roles/ihs/vars/v9.0.5.18.yml
@@ -1,0 +1,19 @@
+---
+ihs_installer_path: WAS/9.0.5ND
+ihs_installer_archive_list:
+  - was.repo.90500.ihs.zip
+  - was.repo.90500.plugins.zip
+  - was.repo.90500.wct.zip
+
+ihs_fp_installer_path: WAS/9.0.5Fixpacks
+ihs_fp_installer_archive_list:
+  - 9.0.5-WS-IHSPLG-FP017.zip
+  # - 9.0.5-WS-IHSPLG-FP018.zip
+  # - 9.0.5-WS-WCT-FP017.zip
+  - 9.0.5-WS-WCT-FP018.zip
+
+ihs_pid: v90_9.0.5017.20230818_1035
+
+# ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.10-linux-x64-installmgr.zip
+ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
+ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/ihs/vars/v9.0.5.18.yml
+++ b/roles/ihs/vars/v9.0.5.18.yml
@@ -7,13 +7,10 @@ ihs_installer_archive_list:
 
 ihs_fp_installer_path: WAS/9.0.5Fixpacks
 ihs_fp_installer_archive_list:
-  - 9.0.5-WS-IHSPLG-FP017.zip
-  # - 9.0.5-WS-IHSPLG-FP018.zip
-  # - 9.0.5-WS-WCT-FP017.zip
+  - 9.0.5-WS-IHSPLG-FP018.zip
   - 9.0.5-WS-WCT-FP018.zip
 
-ihs_pid: v90_9.0.5017.20230818_1035
+ihs_pid: v90_9.0.5018.20231113_1345
 
-# ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.10-linux-x64-installmgr.zip
 ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
 ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/iim/README.md
+++ b/roles/iim/README.md
@@ -10,7 +10,7 @@ None
 
 | Property Name       | Default value                                         |
 | ------------------- | ----------------------------------------------------- |
-| `iim_agent_version` | `1.9.2005.20230718_1844`                              |
+| `iim_agent_version` | `1.9.2006.20230925_1323`                              |
 | `iim_install_path`  | `/opt/IBM/InstallationManager`                        |
 | `download_url`      | # Set this if license and installer is being downloaded from a http server|
 | `download_header`   | # Use this in conjunction with `download_url` |

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-iim_agent_version: 1.9.2005.20230718_1844
+iim_agent_version: 1.9.2006.20230925_1323
+
 # Server info for downloading installers / repos directly, leave blank to copy
 download_url:  # e.g. https://artifactory/repo
 download_header:  # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"

--- a/roles/websphere/defaults/main.yml
+++ b/roles/websphere/defaults/main.yml
@@ -3,7 +3,7 @@
 iim_install_path: /opt/IBM/InstallationManager
 # websphere
 websphere_install_path: /opt/IBM/WebSphere/AppServer
-websphere_version: 9.0.5.17
+websphere_version: 9.0.5.18
 security_username: websphere
 # use encrypted password
 security_password: dummypassword

--- a/roles/websphere/vars/v9.0.5.18.yml
+++ b/roles/websphere/vars/v9.0.5.18.yml
@@ -12,7 +12,6 @@ websphere_base_archive_list:
   - was.repo.90500.nd.zip
 
 # Java Vars
-# websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.10-linux-x64-installmgr.zip
 websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
 websphere_java_pid: com.ibm.java.jdk.v8
 websphere_java_home: java/8.0

--- a/roles/websphere/vars/v9.0.5.18.yml
+++ b/roles/websphere/vars/v9.0.5.18.yml
@@ -1,0 +1,18 @@
+---
+# FP Vars
+websphere_pid: v90_9.0.5018.20231113_1345
+websphere_fp_path: WAS/9.0.5Fixpacks
+websphere_fp_archive_list:
+  - 9.0.5-WS-WAS-FP018.zip
+
+# Base Vars
+websphere_base_pid: com.ibm.websphere.ND.v90
+websphere_base_path: WAS/9.0.5ND
+websphere_base_archive_list:
+  - was.repo.90500.nd.zip
+
+# Java Vars
+# websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.10-linux-x64-installmgr.zip
+websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
+websphere_java_pid: com.ibm.java.jdk.v8
+websphere_java_home: java/8.0


### PR DESCRIPTION
## Summary

Add version files for ihs and websphere v...18
Changes are updating existing vars from version file 17 to point to new uploads on artifactory by uploaded by fergal.

PID retrieved by cracking open some of the zips and comparing 17 to 18 for the filenames containing the PID.

## Story

https://github.com/spm-devops/transformers/issues/932

## Test

<img width="421" alt="image" src="https://github.com/merative/spm-middleware/assets/32648346/aef72bda-fa2b-497d-bc1d-fefe7ad438c0">


Tested locally with `ansible-playbook -i ./hosts --become --private-key=/Users/romakarol/.ssh/id_main_slave_rsa  ./play.yml -e ' websphere_version=9.0.5.18  ihs_version=9.0.5.18 ant_version=1.10.6 ' -e artifactory_token=***`

<img width="960" alt="image" src="https://github.com/merative/spm-middleware/assets/32648346/8282c736-c989-46de-856a-84f7c797e977">


<img width="561" alt="image" src="https://github.com/merative/spm-middleware/assets/32648346/afb0de64-bd30-4cd4-a8d4-4813eb721cb8">
