### PR TITLE
Add JDK21 for liberty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
           - ohs-v12.2.1-rockylinux8
           - liberty-rockylinux8
           - liberty-jdk17-rockylinux8
+          - liberty-jdk21-rockylinux8
           - weblogic-rockylinux8
     steps:
       - name: Checkout

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.5.0
+version: 1.5.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__liberty21/converge.yml
+++ b/molecule/__liberty21/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+
+  collections:
+    - merative.spm_middleware
+
+  vars:
+    liberty_version: "23.0.0.12-JDK21"
+    download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
+
+  roles:
+    - iim
+    - liberty

--- a/molecule/__liberty21/verify.yml
+++ b/molecule/__liberty21/verify.yml
@@ -1,0 +1,30 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  # The pre_tasks section is used to perform some tasks before the main tasks run.
+  # It's a good place for setup tasks or data collection.
+  pre_tasks:
+    - name: Check packages
+      # Assuming 'iim_info' module is part of the 'iim' role or a custom module.
+      # If it's a custom module, ensure that it's properly located in the 'library' directory inside the role.
+      iim_info:
+        iim_path: /opt/IBM/InstallationManager
+      register: iim_info
+    - name: Get jvm.options
+      slurp:
+        src: /opt/IBM/WebSphere/Liberty/usr/shared/jvm.options
+      register: jvm_options
+
+  tasks:
+    - name: Check that the correct packages are installed
+      # Using 'assert' module to validate conditions.
+      assert:
+        that:
+          - "iim_info.packages | select('match', 'com.ibm.websphere.liberty.ND.*') | list | length > 0"
+    - name: Check that jvm.options contains the expected content
+      # Using 'assert' module to check if '-Xmx1024m' is present in 'jvm.options' file.
+      assert:
+        that:
+          - "'-Xmx1024m' in (jvm_options['content'] | b64decode)"

--- a/molecule/liberty-jdk21-rockylinux8/molecule.yml
+++ b/molecule/liberty-jdk21-rockylinux8/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux8
+    image: rockylinux:8
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__liberty21/converge.yml
+    verify: ../__liberty21/verify.yml

--- a/roles/liberty/tasks/main.yml
+++ b/roles/liberty/tasks/main.yml
@@ -18,12 +18,36 @@
     pack_id: "com.ibm.websphere.liberty.ND_{{ liberty_pid }}"
   when: not iim_info.exact_installed
 
-- name: Install Java
+- name: Install Java (iim way)
   include_tasks: fixpack_install.yml
   vars:
     liberty_fp_path: "{{ liberty_java_zip_path }}"
     pack_id: "{{ liberty_java_pid }}"
-  when: not iim_info.exact_installed
+  when: (not iim_info.exact_installed) and ( jdk_installation_way is undefined )
+
+- name: Download JDK (unzip way)
+  get_url:
+    dest: /tmp/jdk.zip
+    url: "{{ download_url }}/{{ liberty_java_zip_path }}"
+    headers: "{{ download_header }}"
+  when: (download_url is defined) and ( jdk_installation_way is defined )
+
+- name: Prepare Open JDK Folder (unzip way)
+  file:
+    path: "{{ liberty_install_path }}/java/{{ jdk_version }}"
+    state: directory
+    owner: root
+    group: root
+  when: jdk_installation_way is defined
+
+- name: Install Java (unzip way)
+  unarchive:
+    src: /tmp/jdk.zip
+    dest: "{{ liberty_install_path }}/java/{{ jdk_version }}"
+    creates: "{{ liberty_install_path }}/java/{{ jdk_version }}/repository.config"
+    extra_opts: [--strip-components=1]
+    remote_src: yes
+  when: jdk_installation_way is defined
 
 - name: Create /opt/Props
   file:

--- a/roles/liberty/vars/v23.0.0.12-JDK21.yml
+++ b/roles/liberty/vars/v23.0.0.12-JDK21.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/23.0.0.12-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 23.0.12.20231127_1901
+jdk_version: 21.0
+jdk_installation_way: unzip
+liberty_java_zip_path: Java/IBM/ibm-semeru-open-jdk_x64_linux_21.0.2_13_openj9-0.43.0.tar.gz


### PR DESCRIPTION
Add JDK21 support on 23.0.0.12. This is for a POC project.
Add a new var file: 23.0.0.12-JDK21.yml .
To use this combination, need to set liberty_version to 23.0.0.12-JDK21 in parent playbook