### PR TITLE
Update Java version for IHS & WAS

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.5.6
+version: 1.5.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ihs/vars/v9.0.5.19.yml
+++ b/roles/ihs/vars/v9.0.5.19.yml
@@ -12,5 +12,5 @@ ihs_fp_installer_archive_list:
 
 ihs_pid: v90_9.0.5019.20240304_1205
 
-ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
+ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.20-linux-x64-installmgr.zip
 ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/websphere/vars/v9.0.5.19.yml
+++ b/roles/websphere/vars/v9.0.5.19.yml
@@ -12,6 +12,6 @@ websphere_base_archive_list:
   - was.repo.90500.nd.zip
 
 # Java Vars
-websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.15-linux-x64-installmgr.zip
+websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.20-linux-x64-installmgr.zip
 websphere_java_pid: com.ibm.java.jdk.v8
 websphere_java_home: java/8.0


### PR DESCRIPTION
Update Java version for IHS & WAS.  
Update to use FP20 as suggested here - https://www.ibm.com/support/pages/node/317689#W9J8

Molecule test for WAS & IHS passed with new Java Version