### PR TITLE
Update DB2 version for Github Workflow test to. 11.5.9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         scenario:
           - websphere-v90-rockylinux8
-          - db21158
+          - db21159
           - oracle19c-rockylinux8
           - iim-191-rockylinux8
           - ihs-v90-rockylinux8

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.5.6
+version: 1.5.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Update DB2 version for Github Workflow test now that DB2 Fixpack 11.5.9.0 is available