### PR TITLE
Hardcode Requests package version

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -7,3 +7,4 @@ ansible-lint
 yamllint
 passlib
 jmespath
+requests==2.31.0

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.6.0
+version: 1.6.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ansible-lint
 yamllint
 passlib
 jmespath
+requests==2.31.0


### PR DESCRIPTION
Hardcode Requests package version

This is due to the recent update to this package which breaks running the molecule tests.
[requestsissue.txt](https://github.com/merative/spm-middleware/files/15388041/requestsissue.txt)

See https://github.com/psf/requests/issues/6707
