### PR TITLE
Fix failing NodeManager call

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.6.2
+version: 1.6.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ohs/tasks/config.yml
+++ b/roles/ohs/tasks/config.yml
@@ -302,14 +302,26 @@
   ignore_errors: True
   changed_when: False
 
+- name: Copy NodeManager Start
+  become: yes
+  become_user: root
+  copy:
+    src: "{{ ohs_home }}/user_projects/domains/ohs_{{ ansible_hostname }}/bin/startNodeManager.sh"
+    dest: /usr/local/bin/startNodeManager.sh
+
+- name: Copy NodeManager Stop
+  become: yes
+  become_user: root
+  copy:
+    src: "{{ ohs_home }}/user_projects/domains/ohs_{{ ansible_hostname }}/bin/stopNodeManager.sh"
+    dest: /usr/local/bin/stopNodeManager.sh
+
 - name: Starting and authenticating NM
   block:
-
     - name: Copy ohsNM.service
       template:
         src: ohsNM.service.j2
         dest: /etc/systemd/system/ohsNM.service
-
     - name: Start service
       systemd:
         name: ohsNM.service

--- a/roles/ohs/templates/ohsNM.service.j2
+++ b/roles/ohs/templates/ohsNM.service.j2
@@ -5,8 +5,8 @@ Description=Oracle HTTP Server service
 User={{ ohs_user }}
 Group={{ ohs_group }}
 Environment="ORACLE_HOME={{ ohs_home }}"
-ExecStart={{ ohs_home }}/user_projects/domains/ohs_{{ ansible_hostname }}/bin/startNodeManager.sh
-ExecStop={{ ohs_home }}/user_projects/domains/ohs_{{ ansible_hostname }}/bin/stopNodeManager.sh
+ExecStart=/usr/local/bin/startNodeManager.sh
+ExecStop=/usr/local/bin/stopNodeManager.sh
 Restart=always
 
 [Install]


### PR DESCRIPTION
NodeManager serice failing to run due to permissions issue

Quick fix is to move the start & stop sh files to /usr/local/bin and update systemd service to point to there new files.

Tested on a VM deployment with OHS and this works.