### PR TITLE
Update WebSphere Liberty (java 8) to v24.0.0.9

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.6.9
+version: 1.7.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__liberty/converge.yml
+++ b/molecule/__liberty/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "24.0.0.6"
+    liberty_version: "24.0.0.9"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/roles/liberty/README.md
+++ b/roles/liberty/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) must already be installed in the target environ
 | Property Name           | Default value                                       |
 | ----------------------- | --------------------------------------------------- |
 | `liberty_install_path`  | `/opt/IBM/WebSphere/Liberty`                        |
-| `liberty_version`       | `24.0.0.6`                                          |
+| `liberty_version`       | `24.0.0.9`                                          |
 | `liberty_default_heapsize`  | `1024m`                                         |
 | `liberty_enable_verbose_gc` | `false`                                         |
 | `liberty_extra_jvm_options` | `[]`                                            |
@@ -37,7 +37,7 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.liberty
-      liberty_version: 24.0.0.6
+      liberty_version: 24.0.0.9
 ```
 
 ## License

--- a/roles/liberty/defaults/main.yml
+++ b/roles/liberty/defaults/main.yml
@@ -3,7 +3,7 @@ iim_install_path: /opt/IBM/InstallationManager
 
 liberty_install_path: /opt/IBM/WebSphere/Liberty
 
-liberty_version: 24.0.0.6
+liberty_version: 24.0.0.9
 
 jdk_version: 8.0
 

--- a/roles/liberty/vars/v24.0.0.9.yml
+++ b/roles/liberty/vars/v24.0.0.9.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/24.0.0.9-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 24.0.9.20240827_1743
+
+liberty_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.30-linux-x64-installmgr.zip
+liberty_java_pid: com.ibm.java.jdk.v8_8.0.8030.20240801_0349


### PR DESCRIPTION
Update WebSphere Liberty (java 8) to v24.0.0.9 - new yaml file Update READMEs
Update Molecule tests
Update galaxy file