### PR TITLE
Update WebSphere Liberty (java 17 & 21) to v24.0.0.9

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.7.0
+version: 1.7.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__liberty17/converge.yml
+++ b/molecule/__liberty17/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "24.0.0.3-JDK17"
+    liberty_version: "24.0.0.9-JDK17"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty21/converge.yml
+++ b/molecule/__liberty21/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "24.0.0.3-JDK21"
+    liberty_version: "24.0.0.9-JDK21"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/roles/liberty/vars/v24.0.0.9-JDK17.yml
+++ b/roles/liberty/vars/v24.0.0.9-JDK17.yml
@@ -1,0 +1,8 @@
+---
+liberty_fp_path: WLP/24.0.0.9-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 24.0.9.20240827_1743
+jdk_version: 17.0
+
+liberty_java_zip_path: Java/IBM/ibm-semeru-certified-jdk_x64_linux_17.0.12.1-installmgr.zip
+liberty_java_pid: com.ibm.java.jdk.v17_17.0.12001.20240913_0245

--- a/roles/liberty/vars/v24.0.0.9-JDK21.yml
+++ b/roles/liberty/vars/v24.0.0.9-JDK21.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/24.0.0.9-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 24.0.9.20240827_1743
+jdk_version: 21.0
+jdk_installation_way: unzip
+liberty_java_zip_path: Java/IBM/ibm-semeru-open-jdk_x64_linux_21.0.4_7_openj9-0.46.1.tar.gz


### PR DESCRIPTION
Update WebSphere Liberty (java 17 & java 21) to v24.0.0.9 - new yaml file Update Molecule tests
Update galaxy file