### PR TITLE
OHS Base YAML install file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.7.4
+version: 1.7.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -37,10 +37,11 @@
 - name: Print ohs_version_status
   debug:
     msg: "{{ ohs_version_status }}"
+  when: ohs_version is defined
 
 - name: Patch OHS
   include_tasks: "patch.yml"
-  when: ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
+  when: ohs_version is defined
 
 - name: Set up properties file
   include_tasks: "config.yml"

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Patch OHS
   include_tasks: "patch.yml"
-  when: ohs_version is defined
+  when: ohs_version is defined and ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
 
 - name: Set up properties file
   include_tasks: "config.yml"

--- a/roles/ohs/vars/v12.2.1.4.0.yml
+++ b/roles/ohs/vars/v12.2.1.4.0.yml
@@ -1,0 +1,24 @@
+---
+# Base installer values
+ohs_version_folder: 12.2.1
+base_version: 12.2.1.4.0
+base_installer: fmw_12.2.1.4.0_ohs_linux64.bin
+base_installer_path: "OHS/12.2.1/fmw_12.2.1.4.0_ohs_linux64.bin"
+# Patches information
+#ohs_version: 12.2.1.4.240115
+#patches:
+#  - filename: "OHS/{{ ohs_version_folder }}/p36187026_122140_Linux-x86-64.zip"
+#    number: 36187026
+#  - filename: "OHS/{{ ohs_version_folder }}/p31101341_122140_Generic.zip"
+#    number: 31101341
+# Add OPatch values when bundled OPatch needs to be upgraded
+opatch_filename_path: "WLS/Patches/p28186730_1394215_Generic.zip"
+opatch_version: 13.9.4.2.15
+opatch_folder: 6880880
+
+# Full jdk is needed to update OPatch
+java_zip_path: 'WLS/jdk-8u411-linux-x64.tar.gz'
+java_version_path: 'jdk1.8.0_411'
+jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
+
+template_jar: "ohs_standalone_template.jar"


### PR DESCRIPTION
I am trying manually work around https://github.com/spm-devops/transformers/issues/1327 - until this is fixed.

On a VM i can manually install all the required pieces i.e. OHS Base
OHS 19c Upgrade
OHS 19c latest patches

However manually it is more difficult to complete the OHS config for Curam -  as this has a number of steps including creating SSL certs etc.

To help this I have created a YAML file to just install the Base version of OHS.  This will mean when i choose this version when deploying a VM - it will in stall the base and configure OHS for use with Curam..  I can then manually install the 19c upgrade and latest patches - and OHS should be automatically configured for me (from the base install)

This changeset has a YAML file which just installs the Base version (commented out the patches information).  There is a change needed to the ohs main yaml file - to only Patch OHS when the ohs_version variable is set - which it should be for all other yamls (outside of the base)

Tested this locally on molecule - and it looks to pass for both the Base install and latest 12c fixpacks..

If this works will be first step in trying to solve the above transformers ticket.