### PR TITLE
OHS Base Install - Improve checks on Patch OHS when there are no patches

### DIFF
--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Patch OHS
   include_tasks: "patch.yml"
-  when: ohs_version is defined and ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
+  when: ohs_version is defined or ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
 
 - name: Set up properties file
   include_tasks: "config.yml"

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -33,6 +33,7 @@
   changed_when: False
   ignore_errors: True
   loop: "{{ patches }}"
+  when: ohs_version is defined
 
 - name: Print ohs_version_status
   debug:
@@ -41,7 +42,7 @@
 
 - name: Patch OHS
   include_tasks: "patch.yml"
-  when: ohs_version is defined or ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
+  when: ohs_version is defined and ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
 
 - name: Set up properties file
   include_tasks: "config.yml"

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -42,7 +42,10 @@
 
 - name: Patch OHS
   include_tasks: "patch.yml"
-  when: ohs_version is defined and ohs_version_status.results | selectattr('rc','greaterthan',0) | list | count > 0
+  when: 
+    - patches | length > 0
+    - ohs_version is defined
+    - ohs_version_status.results | selectattr('rc', 'greaterthan', 0) | list | count > 0
 
 - name: Set up properties file
   include_tasks: "config.yml"


### PR DESCRIPTION
OHS Base Install - Improve checks on Patch OHS when there are no patches

Failed when deploying VM in Jenkins.. despite all molecule tests passing when submitting initial change
https://spmdevops-team-apollo.jenkins.commops.merative.com/job/DevOps-Jenkins-ProvisionerWrapper/1115/

Added in improved checks to determine of OHS should be patched based off contents in yaml file