### PR TITLE
Update OHS code to upgrade to 19c Client

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.7.6
+version: 1.7.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ohs-v12.2.1.4/converge.yml
+++ b/molecule/__ohs-v12.2.1.4/converge.yml
@@ -32,7 +32,7 @@
         name: weblogic
       vars:
         ansible_python_interpreter: /usr/bin/python3
-        weblogic_version: "14.1.1.0.240328"
+        weblogic_version: "14.1.1.0.240922"
 
     - name: include ohs
       include_role:

--- a/molecule/__ohs-v12.2.1.4/verify.yml
+++ b/molecule/__ohs-v12.2.1.4/verify.yml
@@ -4,7 +4,7 @@
 
   pre_tasks:
     - name: include vars
-      include_vars: "../../roles/ohs/vars/v12.2.1.4.240115.yml"
+      include_vars: "../../roles/ohs/vars/v12.2.1.4.240906.yml"
 
     - name: include default
       include_vars: "../../roles/ohs/defaults/main.yml"

--- a/roles/ohs/README.md
+++ b/roles/ohs/README.md
@@ -14,7 +14,7 @@ NOTE: Update these default usernames and passwords after the initial installatio
 
 | Property Name             | Default value                                       |
 | ------------------------- | --------------------------------------------------- |
-| `ohs_version`             | `12.2.1.4.210324`                                   |
+| `ohs_version`             | `12.2.1.4.240906`                                   |
 | `ohs_user`                | `oracle`                                            |
 | `ohs_admin_password`      | `password1`                                         |
 | `ohs_group`               | `oinstall`                                          |
@@ -41,7 +41,7 @@ Although the role can be used independently, it is expected that Weblogic is alr
 - hosts: all
   roles:
     - role: merative.spm_middleware.ohs
-      ohs_version: 12.2.1.4.210324
+      ohs_version: 12.2.1.4.240906
 ```
 ## License
 

--- a/roles/ohs/defaults/main.yml
+++ b/roles/ohs/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # OHS config
-ohs_version: 12.2.1.4.240115
+ohs_version: 12.2.1.4.240906
 ohs_user: oracle
 ohs_admin_password: Password1
 ohs_group: oinstall

--- a/roles/ohs/tasks/19cupgrade.yml
+++ b/roles/ohs/tasks/19cupgrade.yml
@@ -1,0 +1,69 @@
+---
+
+- name: Create 19cUpgrade zip directory
+  ansible.builtin.file:
+    path: "{{ ohs_installer_loc }}/19cUpgrade/"
+    state: directory
+    owner: "{{ ohs_user }}"
+    group: "{{ ohs_group }}"
+    mode: 0755
+
+- name: Check 19cUpgrade Installer File Exists
+  stat:
+    path: "{{ ohs_installer_loc }}/19cUpgrade/{{ upgrade19c_installer_zip }}"
+  register: installer
+
+- name: Download 19cUpgrade installer
+  get_url:
+    url: "{{ download_url }}/{{ upgrade19c_installer_path }}/{{ upgrade19c_installer_zip }}"
+    dest: "{{ ohs_installer_loc }}/19cUpgrade/"
+    owner: "{{ ohs_user }}"
+    group: "{{ ohs_group }}"
+    mode: 0755
+    force: no
+    headers: "{{ download_header }}"
+  when: not installer.stat.exists and download_url is defined
+
+- name: Create 19cUpgrade unzipped directory
+  ansible.builtin.file:
+    path: "{{ ohs_installer_loc }}/upgrade19cInstaller/"
+    state: directory
+    owner: "{{ ohs_user }}"
+    group: "{{ ohs_group }}"
+    mode: 0755
+
+- name: Unzip 19c Upgrade installer
+  ansible.builtin.unarchive:
+    src: "{{ ohs_installer_loc }}/19cUpgrade/{{ upgrade19c_installer_zip }}"
+    dest: "{{ ohs_installer_loc }}/upgrade19cInstaller/"
+    owner: "{{ ohs_user }}"
+    group: "{{ ohs_group }}"
+    mode: 0755
+    remote_src: yes
+  when: not installer.stat.exists
+
+- name: Update permissions for a directory and its contents
+  ansible.builtin.file:
+    path: "{{ ohs_installer_loc }}/upgrade19cInstaller/{{ upgrade19c_installer_folder }}"
+    mode: 0755
+    recurse: yes
+
+- name: Upgrade Prep Change Permissions
+  become: yes
+  become_user: "{{ ohs_user }}"
+  command: "{{ ohs_installer_loc }}/upgrade19cInstaller/{{ upgrade19c_installer_folder }}/changePerm.sh {{ ohs_home }}"
+
+- name: Execute 19c Upgrade 
+  become: yes
+  become_user: "{{ ohs_user }}"
+  command: "{{ ohs_installer_loc }}/upgrade19cInstaller/{{ upgrade19c_installer_folder }}/{{ upgrade19c_installer }} -ignoreSysPrereqs -invPtrLoc {{ ohs_home }}/oraInst.loc -silent ORACLE_HOME={{ ohs_home }}"
+
+- name: Cleanup
+  file:
+    path: "{{ ohs_installer_loc }}/upgrade19cInstaller"
+    state: absent
+
+- name: Cleanup
+  file:
+    path: "{{ ohs_installer_loc }}/19cUpgrade"
+    state: absent

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: "Include v{{ ohs_version }}.yml variables"
   include_vars: "v{{ ohs_version }}.yml"
 
-- name: check if OHS already installed
+- name: Check if OHS already installed
   shell: "grep {{ base_version }} {{ ohs_home }}/inventory/registry.xml"
   changed_when: False
   ignore_errors: True
@@ -24,6 +24,16 @@
 - name: Install Base version
   include_tasks: "base_install.yml"
   when: base_version is defined and base_installed.rc != 0
+
+- name: Check if OHS is upgraded to 19c
+  shell: "grep {{ upgrade19c_version }} {{ ohs_home }}/inventory/registry.xml"
+  changed_when: False
+  ignore_errors: True
+  register: base_upgraded
+
+- name: Upgrade to OHS 19c
+  include_tasks: "19cupgrade.yml"
+  when: upgrade19c_version is defined and base_upgraded.rc != 0
 
 - name: Check if Patch already applied
   become: yes

--- a/roles/ohs/tasks/patch.yml
+++ b/roles/ohs/tasks/patch.yml
@@ -68,7 +68,7 @@
   when: opatch_version is defined and opatch_status.rc != 0
 
 - name: Patch OPatch tool
-  command: "{{ ohs_home }}/oracle_common/jdk/bin/java -jar {{ ohs_installer_loc }}/{{ opatch_folder }}/opatch_generic.jar -silent oracle_home={{ ohs_home }}"
+  command: "{{ ohs_home }}/oracle_common/jdk/bin/java -jar {{ ohs_installer_loc }}/{{ opatch_folder }}/opatch_generic.jar -ignoreSysPrereqs -silent oracle_home={{ ohs_home }}"
   become: yes
   become_user: "{{ ohs_user }}"
   when: opatch_version is defined and opatch_status.rc != 0

--- a/roles/ohs/vars/v12.2.1.4.240906.yml
+++ b/roles/ohs/vars/v12.2.1.4.240906.yml
@@ -1,0 +1,31 @@
+---
+# Base Information
+ohs_version_folder: 12.2.1
+base_version: 12.2.1.4.0
+base_installer: fmw_12.2.1.4.0_ohs_linux64.bin
+base_installer_path: "OHS/12.2.1/fmw_12.2.1.4.0_ohs_linux64.bin"
+
+# Upgrade Information
+upgrade19c_version: 12.2.1.19.0
+upgrade19c_installer_path: "OHS/12.2.1/19cUpgrade"
+upgrade19c_installer_zip: "p34761383_122140_Linux-x86-64.zip"
+upgrade19c_installer: fmw_12.2.1.19.0_dbclient_linux64.bin
+upgrade19c_installer_folder: 34761383
+
+# Patch information
+ohs_version: 12.2.1.4.240906
+patches:
+  - filename: "OHS/{{ ohs_version_folder }}/p37033394_122140_Linux-x86-64.zip"
+    number: 37033394
+
+# OPatch Information
+opatch_filename_path: "WLS/Patches/p28186730_1394217_Generic.zip"
+opatch_version: 13.9.4.2.17
+opatch_folder: 6880880
+
+# JDK Information
+java_zip_path: 'WLS/jdk-8u431-linux-x64.tar.gz'
+java_version_path: 'jdk1.8.0_431'
+jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
+
+template_jar: "ohs_standalone_template.jar"


### PR DESCRIPTION
Up to now we have been installing the 12c Client for the Oracle HTTP Server.  This is already or about to go out of support.  So we need to switch to the supported version i.e. 19C Client..

Initially a ticket was created for this work - https://github.com/spm-devops/transformers/issues/1327

But the code deliever in this PR should cover what is required.

New Oracle 19c Upgrade Yaml file
Updates to existing main & patch yaml to accomodate changes in the Upgrade
Latest 19c fixpacks for patching
Updated molecule tests
Update README
Update Galaxy.yml

All molecule tests passing locally for latest 19c patches and for last 12c patch