### PR TITLE
Update 19c patch var file - add in new patch/fix zip

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.7.7
+version: 1.7.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ohs/vars/v12.2.1.4.240906.yml
+++ b/roles/ohs/vars/v12.2.1.4.240906.yml
@@ -17,6 +17,8 @@ ohs_version: 12.2.1.4.240906
 patches:
   - filename: "OHS/{{ ohs_version_folder }}/p37033394_122140_Linux-x86-64.zip"
     number: 37033394
+  - filename: "OHS/{{ ohs_version_folder }}/p35333510_122140_Linux-x86-64.zip"
+    number: 35037811
 
 # OPatch Information
 opatch_filename_path: "WLS/Patches/p28186730_1394217_Generic.zip"


### PR DESCRIPTION
**_Summary_**
When deploying OHS with DB Client 19c version we saw an issue logging into Curam post deployment.

This meant there was issues decoding content and ultimately resources (e.g. css files) not being downloaded and impacting the visual and usability of Curam.

**_Errors_**
From investigation we found errors in the logs
`[2024-12-04T15:29:26.6689+00:00] [OHS] [ERROR:32] [OH99999] [weblogic] [client_id: 172.32.0.6] [host_id: mfohstest] [host_addr: 10.0.0.247] [pid: 687368] [tid: 140379588388608] [user: root] [ecid: 006A7Dimq5vFGB05zzG7yW002bo8000007] [rid: 0] [VirtualHost: mfohstest.internal.cloudapp.net:443] ap_proxy: trying GET /Curam/CDEJ/css/custom.css at backend host 10.0.0.247/7002, client 172.32.0.6/49798, total tries 1; got exception 'PROTOCOL_ERROR [line 1010 of URL.cpp]: EOF reading CTE chunk size'; state: reading response body from WLS; not failing over, referer https://10.0.0.247/Curam/logon.jsp;jsessionid=H5OSSWh0siDl3Orwep5pow46MeiUV4gpb2zxEYeMnO-n9zxg7-Up!588511954`
`[2024-12-04T15:29:26.6707+00:00] [OHS] [ERROR:32] [OH99999] [weblogic] [client_id: 172.32.0.6] [host_id: mfohstest] [host_addr: 10.0.0.247] [pid: 687369] [tid: 140380192368384] [user: root] [ecid: 006A7DimuEcFGB05zzG7yW002bo9000001] [rid: 0] [VirtualHost: mfohstest.internal.cloudapp.net:443] ap_proxy: trying GET /Curam/CDEJ/jscript/cdej.js at backend host 10.0.0.247/7002, client 172.32.0.6/49803, total tries 1; got exception 'PROTOCOL_ERROR [line 1010 of URL.cpp]: EOF reading CTE chunk size'; state: reading response body from WLS; not failing over, referer https://10.0.0.247/Curam/logon.jsp;jsessionid=H5OSSWh0siDl3Orwep5pow46MeiUV4gpb2zxEYeMnO-n9zxg7-Up!588511954`

**_Cause_**
This lead us to find Oracle documentation on the errors and highlighted an extra Patch that looks to be required.
https://support.oracle.com/epmos/faces/DocumentDisplay?_afrLoop=375573192164768&id=2939068.1

The issue was that an existing Oracle Notification Service (ONS) bug/fix was missed and not rolled up into the DBc 19c track. As such, the WebLogic Plugin is not able to properly handle the chunked response over SSL.

This was released in the following Patch - https://support.oracle.com/epmos/faces/PatchDetail?_adf.ctrl-state=19zj90w2rq_4&patchId=35333510&_afrLoop=375570746737057

_**Testing**_
This patch was applied to a server manually and once OHS was restarted we no longer saw issues with Curam.

The changes in this PR adds this new patch and ensures it is applied when deploying

Testing has been completed locally and all molecule tests have passed.

Backup
Similar errors were also seen in this Oracle support Doc - https://support.oracle.com/epmos/faces/DocumentDisplay?_afrLoop=376719113206821&id=3041758.1

It is suggested here that the flow for installing 19c was the cause but i believe we are following the expected process so this is not the cause of the issue above.