### PR TITLE
Add WebLogic support for RHEL 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
           - liberty-jdk17-rockylinux8
           - liberty-jdk21-rockylinux8
           - weblogic-rockylinux8
+          - weblogic-rockylinux9
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.8.6
+version: 1.8.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/weblogic-rockylinux9/molecule.yml
+++ b/molecule/weblogic-rockylinux9/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux9
+    image: rockylinux:9
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    # volume_mounts:
+    #   - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__weblogic-v14.1/converge.yml
+    verify: ../__weblogic-v14.1/verify.yml

--- a/roles/weblogic/meta/main.yml
+++ b/roles/weblogic/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
   galaxy_tags:
     []

--- a/roles/weblogic/vars/os_9.yml
+++ b/roles/weblogic/vars/os_9.yml
@@ -1,0 +1,36 @@
+---
+packages_list:
+  - 'binutils'
+  - 'net-tools'
+  - 'psmisc'
+  - 'shadow-utils'
+  - 'gcc-c++'
+  - 'glibc.x86_64'
+  - 'glibc-devel.x86_64'
+  - 'libaio-devel'
+  - 'libstdc++-devel'
+  - 'ksh'
+  - 'make'
+  - 'sudo'
+  - 'unzip'
+  - 'sysstat'
+  - 'yum-utils'
+  - 'smartmontools'
+kernel_params:
+  kernel.shmmax: "{{ (ansible_memtotal_mb  * 1048576 / 2) |round|int|abs }}"
+  kernel.shmall: "{{ (ansible_memtotal_mb  * 1048576 / 4096) |round|int|abs }}"
+  # net.core.rmem_max: 16777216
+  # net.core.wmem_max: 16777216
+  net.ipv4.tcp_rmem: 4096 87380 16777216
+  net.ipv4.tcp_wmem: 4096 65536 16777216
+  vm.swappiness: 10
+  vm.dirty_background_ratio: 5
+  vm.dirty_ratio: 10
+  fs.file-max: 262144
+  net.ipv4.tcp_keepalive_time: 300
+  net.ipv4.tcp_keepalive_intvl: 60
+  net.ipv4.tcp_keepalive_probes: 10
+soft_no_file: 4096
+hard_no_file: 65536
+soft_nproc: 2047
+hard_nproc: 16384


### PR DESCRIPTION
With RHEL 9 being supported in 8.2.0.0 - we need to ensure that it can deploy correctly.

An initial test on a RHEL9 VM with Weblogic failed due to

`TASK [merative.spm_middleware.weblogic : Include based on OS version variables] ***
fatal: [mfwlsorarhel9]: FAILED! => {"ansible_facts": {}, "ansible_included_var_files": [], "changed": false, "message": "Could not find or access 'os_9.yml'\nSearched in:\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/playbooks/install_middleware/ansible_collections/merative/spm_middleware/roles/weblogic/vars/os_9.yml\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/playbooks/install_middleware/ansible_collections/merative/spm_middleware/roles/weblogic/os_9.yml\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/playbooks/install_middleware/ansible_collections/merative/spm_middleware/roles/weblogic/tasks/vars/os_9.yml\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/playbooks/install_middleware/ansible_collections/merative/spm_middleware/roles/weblogic/tasks/os_9.yml\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/ansible/playbooks/install_middleware/vars/os_9.yml\n\t/home/jenkins/remoting/workspace/DevOps-Jenkins-ProvisionerWrapper/ansible/playbooks/install_middleware/os_9.yml on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}`

This PR covers updates required to support this.

- New os_9 vars file for WLS
- New Molecule test for WLS on Rocky9
- New Github workflow for this test

With support for RHEL9 coming we should possibly start to add in Rocky9 molecule tests alongside the Rocky 8 tests.
Ultimately we will remove support for Rocky8 once we no longer support RHEL8 for customers.