### PR TITLE
Add Oracle HTTP Server support for RHEL 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
           - iim-191-rockylinux8
           - ihs-v90-rockylinux8
           - ohs-v12.2.1.4-rockylinux8
+          - ohs-v12.2.1.4-rockylinux9
           - liberty-rockylinux8
           - liberty-jdk17-rockylinux8
           - liberty-jdk21-rockylinux8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
           - liberty-jdk17-rockylinux8
           - liberty-jdk21-rockylinux8
           - weblogic-rockylinux8
+          - weblogic-rockylinux9
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.8.7
+version: 1.8.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.8.6
+version: 1.8.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/ohs-v12.2.1.4-rockylinux9/molecule.yml
+++ b/molecule/ohs-v12.2.1.4-rockylinux9/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux9
+    image: rockylinux:9
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__ohs-v12.2.1.4/converge.yml
+    verify: ../__ohs-v12.2.1.4/verify.yml

--- a/molecule/weblogic-rockylinux9/molecule.yml
+++ b/molecule/weblogic-rockylinux9/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux9
+    image: rockylinux:9
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    # volume_mounts:
+    #   - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__weblogic-v14.1/converge.yml
+    verify: ../__weblogic-v14.1/verify.yml

--- a/roles/ohs/tasks/config.yml
+++ b/roles/ohs/tasks/config.yml
@@ -191,12 +191,21 @@
         privatekey_path: "{{ ohs_base }}/scripts/ssl/WLSPlugin.key"
         csr_path: "{{ ohs_base }}/scripts/ssl/WLSPlugin.csr"
 
-    - name: Create backend_p12
+    - name: Create backend_p12 on RHEL 8
       become: yes
       become_user: "{{ ohs_user }}"
       command: "openssl pkcs12 -export -in {{ ohs_base }}/scripts/ssl/WLSPlugin.crt -inkey {{ ohs_base }}/scripts/ssl/WLSPlugin.key -out {{ ohs_base }}/scripts/ssl/WLSPlugin.p12 -name selfsigned -password pass:{{ keystore_password }}"
       environment:
         ORACLE_HOME: "{{ ohs_home }}"
+      when: ansible_facts['distribution_version'] is match('^8.*')
+
+    - name: Create backend_p12 on RHEL 9
+      become: yes
+      become_user: "{{ ohs_user }}"
+      command: "openssl pkcs12 -legacy -export -in {{ ohs_base }}/scripts/ssl/WLSPlugin.crt -inkey {{ ohs_base }}/scripts/ssl/WLSPlugin.key -out {{ ohs_base }}/scripts/ssl/WLSPlugin.p12 -name selfsigned -password pass:{{ keystore_password }}"
+      environment:
+        ORACLE_HOME: "{{ ohs_home }}"
+      when: ansible_facts['distribution_version'] is match('^9.*')
 
     - name: Import cert to backend wallet
       become: yes
@@ -270,6 +279,17 @@
         chdir: "{{ ohs_home }}/oracle_common/bin"
       environment:
         ORACLE_HOME: "{{ ohs_home }}"
+      when: ansible_facts['distribution_version'] is match('^8.*')
+
+    - name: Create front end p12
+      become: yes
+      become_user: "{{ ohs_user }}"
+      command: "openssl pkcs12 -legacy -export -in {{ ohs_scripts_loc }}/ssl/FrontCert.crt -inkey {{ ohs_scripts_loc }}/ssl/FrontCert.key -out {{ ohs_scripts_loc }}/ssl/FrontCert.p12 -name selfsigned -password pass:{{ keystore_password }}"
+      args:
+        chdir: "{{ ohs_home }}/oracle_common/bin"
+      environment:
+        ORACLE_HOME: "{{ ohs_home }}"
+      when: ansible_facts['distribution_version'] is match('^9.*')
 
     - name: Import cert to front end wallet
       become: yes

--- a/roles/ohs/tasks/patch.yml
+++ b/roles/ohs/tasks/patch.yml
@@ -107,6 +107,14 @@
     group: "{{ ohs_group }}"
   loop: "{{ patches }}"
 
+- name: Create missing symbolic links for OHS for RH 9
+  file:
+    src: "/usr/lib64/libc_nonshared.a"
+    dest: "/usr/lib64/libpthread_nonshared.a"
+    state: link
+  when: ansible_facts['distribution_version'] is match('^9.*')
+  ignore_errors: true
+
 - name: "Apply Patches"
   become: yes
   become_user: "{{ ohs_user }}"

--- a/roles/weblogic/meta/main.yml
+++ b/roles/weblogic/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
   galaxy_tags:
     []

--- a/roles/weblogic/vars/os_9.yml
+++ b/roles/weblogic/vars/os_9.yml
@@ -1,0 +1,36 @@
+---
+packages_list:
+  - 'binutils'
+  - 'net-tools'
+  - 'psmisc'
+  - 'shadow-utils'
+  - 'gcc-c++'
+  - 'glibc.x86_64'
+  - 'glibc-devel.x86_64'
+  - 'libaio-devel'
+  - 'libstdc++-devel'
+  - 'ksh'
+  - 'make'
+  - 'sudo'
+  - 'unzip'
+  - 'sysstat'
+  - 'yum-utils'
+  - 'smartmontools'
+kernel_params:
+  kernel.shmmax: "{{ (ansible_memtotal_mb  * 1048576 / 2) |round|int|abs }}"
+  kernel.shmall: "{{ (ansible_memtotal_mb  * 1048576 / 4096) |round|int|abs }}"
+  # net.core.rmem_max: 16777216
+  # net.core.wmem_max: 16777216
+  net.ipv4.tcp_rmem: 4096 87380 16777216
+  net.ipv4.tcp_wmem: 4096 65536 16777216
+  vm.swappiness: 10
+  vm.dirty_background_ratio: 5
+  vm.dirty_ratio: 10
+  fs.file-max: 262144
+  net.ipv4.tcp_keepalive_time: 300
+  net.ipv4.tcp_keepalive_intvl: 60
+  net.ipv4.tcp_keepalive_probes: 10
+soft_no_file: 4096
+hard_no_file: 65536
+soft_nproc: 2047
+hard_nproc: 16384


### PR DESCRIPTION
With RHEL 9 being supported in 8.2.0.0 - we need to ensure that it can deploy correctly.

An initial test on a RHEL9 VM with Oracle HTTP Server failed due to the below issues.

**_MIssing SymLink to required lib_**
The OHS install fails patching the system with the following error
`cannot find /usr/lib64/libpthread_nonshared.a`

From research - there seems to be a requirement to create a symlink for this package when installing OHS on RHEL
[Oracle Fusion Middleware 12.2.1.4.0 Support with OL/RHEL9](https://support.oracle.com/epmos/faces/DocumentDisplay?_afrLoop=352982423210827&parent=DOCUMENT&sourceId=3035477.1&id=2936471.1&_afrWindowMode=0&_adf.ctrl-state=2j7g5v45u_53)

The suggestion in this doc is

`Non-java installTypes (OBIEE, Oracle Forms and Reports, Oracle HTTP Server, Oracle Internet Directory, Oracle Traffic Director, Oracle WebLogic Proxy Plugin) complete following steps:`

`a. As root user create symbolic link for libpthread_nonshared.a`
`cd /usr/lib64`
`ln -s libc_nonshared.a libpthread_nonshared.a`

`b. Press "Skip" button to continue to next page`

**_Cert creation issues on RHEL 9_**
Once the symlink was fixed there was a further issue creating and importing the backend and frontend p12 cert to the Oracle HTTP Server..

The error thrown is:
`oracle.security.crypto.core.CipherException: `
`oracle.security.crypto.core.InvalidKeyException: `
`oracle.security.crypto.core.AlgorithmIdentifierException: `
`No class found for OBJECT IDENTIFIER {1 2 840 113549 2 9}`

This Oracle [Doc](https://support.oracle.com/epmos/faces/DocumentDisplay?_afrLoop=354245074389585&parent=EXTERNAL_SEARCH&sourceId=PROBLEM&id=2966768.1&_afrWindowMode=0&_adf.ctrl-state=2j7g5v45u_180) related to Oracle HTTP Server seems to have the same error.. The suggestion was to add the following to the keytool command - `Add parameter " -J-Dkeystore.pkcs12.legacy" to keytool command.`

However we don't use keytool, we have Oracle `orapki`
So further [research](https://stackoverflow.com/questions/70431528/mac-verification-failed-during-pkcs12-import-wrong-password-azure-devops) suggested the issue might be creating the cert with openssl - so i added a -legacy flag to the openssl command.

This seem to work, in that the cert was imported, and the rest of the install completed successfully

Now i need to see if this impacts a deployed application on a VM