### PR TITLE
Update IBM Middleware to latest Fixpacks

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.8.9
+version: 1.9.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ihs-v85/converge.yml
+++ b/molecule/__ihs-v85/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 8.5.5.25
+    ihs_version: 8.5.5.27
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__ihs-v90/converge.yml
+++ b/molecule/__ihs-v90/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 9.0.5.22
+    ihs_version: 9.0.5.23
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty/converge.yml
+++ b/molecule/__liberty/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "24.0.0.12"
+    liberty_version: "25.0.0.3"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty21/converge.yml
+++ b/molecule/__liberty21/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "24.0.0.12-JDK21"
+    liberty_version: "25.0.0.3-JDK21"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v85/converge.yml
+++ b/molecule/__websphere-v85/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    websphere_version: 8.5.5.25
+    websphere_version: 8.5.5.27
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v90/converge.yml
+++ b/molecule/__websphere-v90/converge.yml
@@ -6,9 +6,9 @@
     - merative.spm_middleware
 
   vars:
-    iim_agent_version: 1.9.3000.20240905_1526
+    iim_agent_version: 1.9.3001.20250403_2010
     iim_install_path: /opt/IBM/InstallationManager
-    websphere_version: 9.0.5.22
+    websphere_version: 9.0.5.23
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/iim-191-rockylinux8/converge.yml
+++ b/molecule/iim-191-rockylinux8/converge.yml
@@ -9,6 +9,6 @@
     - iim
 
   vars:
-    iim_agent_version: 1.9.3000.20240905_1526
+    iim_agent_version: 1.9.3001.20250403_2010
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/molecule/iim-191-rockylinux9/converge.yml
+++ b/molecule/iim-191-rockylinux9/converge.yml
@@ -9,6 +9,6 @@
     - iim
 
   vars:
-    iim_agent_version: 1.9.3000.20240905_1526
+    iim_agent_version: 1.9.3001.20250403_2010
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/roles/ihs/README.md
+++ b/roles/ihs/README.md
@@ -13,18 +13,18 @@ NOTE: ihs_admin_pass should be changed after first installation.
 | `ihs_install_path`      | `/opt/IBM/HTTPServer`                               |
 | `plg_install_path`      | `/opt/IBM/WebSphere/Plugins`                        |
 | `wct_install_path`      | `/opt/IBM/WebSphere/Toolbox`                        |
-| `ihs_version`           | `9.0.5.22`                                           |
+| `ihs_version`           | `9.0.5.23`                                           |
 | `ihs_config_type`       | `local_distributed`                                 |
 | `ihs_admin_user`        | `wasadmin`                                          |
 | `ihs_admin_pass`        | `wasadmin`                                          |
 | ----------------------- | --------------------------------------------------- |
-| Version-specific:       | Values from `9.0.5.22`                               |
+| Version-specific:       | Values from `9.0.5.23`                               |
 | ----------------------- | --------------------------------------------------- |x  
 | `ihs_installer_archive_list` | `was.repo.90500.[ihs|plugins|wct].zip`         |
 | `ihs_fp_installer_path` | `WAS/9.0.5Fixpacks`                                 |
 | `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP022.zip`           |
-| `ihs_pid`               | `v90~9.0.5022.20241118_0055`                        |
-| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.35-linux-x64-installmgr.zip` |
+| `ihs_pid`               | `v90~9.0.5023.20250307_1839`                        |
+| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.40-linux-x64-installmgr.zip` |
 | `ihs_java_pid`          | `com.ibm.java.jdk.v8`                               |
 | ----------------------- | --------------------------------------------------- |
 | `iim_install_path`      | `/opt/IBM/InstallationManager`                      |
@@ -53,7 +53,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware.iim
     - merative.spm_middleware.ihs
       vars:
-        - ihs_version: 9.0.5.22
+        - ihs_version: 9.0.5.23
         - download_url: "https://myserver.com/IHS/repos"
         - download_header: { 'Authorization': 'Basic EncodedString'}
 ```

--- a/roles/ihs/defaults/main.yml
+++ b/roles/ihs/defaults/main.yml
@@ -5,7 +5,7 @@ ihs_install_path: /opt/IBM/HTTPServer
 plg_install_path: /opt/IBM/WebSphere/Plugins
 wct_install_path: /opt/IBM/WebSphere/Toolbox
 
-ihs_version: 9.0.5.22
+ihs_version: 9.0.5.23
 
 ihs_config_type: local_distributed
 ihs_admin_user: wasadmin

--- a/roles/ihs/vars/v8.5.5.27.yml
+++ b/roles/ihs/vars/v8.5.5.27.yml
@@ -1,0 +1,19 @@
+---
+ihs_installer_path: WAS/8.5.5ND
+ihs_installer_archive_list:
+  - WAS_V8.5.5_SUPPL_1_OF_3.zip
+  - WAS_V8.5.5_SUPPL_2_OF_3.zip
+  - WAS_V8.5.5_SUPPL_3_OF_3.zip
+
+ihs_fp_installer_path: WAS/8.5.5Fixpacks/FP27
+ihs_fp_installer_archive_list:
+  - 8.5.5-WS-WASSupplements-FP027-part1.zip
+  - 8.5.5-WS-WASSupplements-FP027-part2.zip
+  - 8.5.5-WS-WASSupplements-FP027-part3.zip
+
+ihs_wct_installer_list:
+  - 8.5.5-WS-WCT-FP027-part1.zip
+  - 8.5.5-WS-WCT-FP027-part2.zip
+
+ihs_pid: v85_8.5.5027.20250129_1123
+ihs_base_pid: v85_8.5.5000.20130514_1044

--- a/roles/ihs/vars/v9.0.5.23.yml
+++ b/roles/ihs/vars/v9.0.5.23.yml
@@ -1,0 +1,16 @@
+---
+ihs_installer_path: WAS/9.0.5ND
+ihs_installer_archive_list:
+  - was.repo.90500.ihs.zip
+  - was.repo.90500.plugins.zip
+  - was.repo.90500.wct.zip
+
+ihs_fp_installer_path: WAS/9.0.5Fixpacks
+ihs_fp_installer_archive_list:
+  - 9.0.5-WS-IHSPLG-FP023.zip
+  - 9.0.5-WS-WCT-FP023.zip
+
+ihs_pid: v90_9.0.5023.20250307_1839
+
+ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.40-linux-x64-installmgr.zip
+ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/iim/README.md
+++ b/roles/iim/README.md
@@ -10,7 +10,7 @@ None
 
 | Property Name       | Default value                                         |
 | ------------------- | ----------------------------------------------------- |
-| `iim_agent_version` | `1.9.3000.20240905_1526`                              |
+| `iim_agent_version` | `1.9.3001.20250403_2010`                              |
 | `iim_install_path`  | `/opt/IBM/InstallationManager`                        |
 | `download_url`      | # Set this if license and installer is being downloaded from a http server|
 | `download_header`   | # Use this in conjunction with `download_url` |

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-iim_agent_version: 1.9.3000.20240905_1526
+iim_agent_version: 1.9.3001.20250403_2010
 
 # Server info for downloading installers / repos directly, leave blank to copy
 download_url:  # e.g. https://artifactory/repo

--- a/roles/liberty/defaults/main.yml
+++ b/roles/liberty/defaults/main.yml
@@ -3,7 +3,7 @@ iim_install_path: /opt/IBM/InstallationManager
 
 liberty_install_path: /opt/IBM/WebSphere/Liberty
 
-liberty_version: 24.0.0.12
+liberty_version: 25.0.0.3
 
 jdk_version: 8.0
 

--- a/roles/liberty/vars/v25.0.0.3-JDK21.yml
+++ b/roles/liberty/vars/v25.0.0.3-JDK21.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/25.0.0.3-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 25.0.3.20250310_1903
+jdk_version: 21.0
+jdk_installation_way: unzip
+liberty_java_zip_path: Java/IBM/ibm-semeru-open-jdk_x64_linux_21.0.6_7_openj9-0.49.0.tar.gz

--- a/roles/liberty/vars/v25.0.0.3.yml
+++ b/roles/liberty/vars/v25.0.0.3.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/25.0.0.3-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 25.0.3.20250310_1903
+
+liberty_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.40-linux-x64-installmgr.zip
+liberty_java_pid: com.ibm.java.jdk.v8_8.0.8040.20250128_0059

--- a/roles/websphere/README.md
+++ b/roles/websphere/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) or higher must already be installed in the targ
 | Property Name            | Default value                                       |
 | ------------------------ | --------------------------------------------------- |
 | `websphere_install_path` | `/opt/IBM/WebSphere/AppServer`                      |
-| `websphere_version`      | `9.0.5.22`                                           |
+| `websphere_version`      | `9.0.5.23`                                           |
 | ------------------------ | --------------------------------------------------- |
 | `iim_install_path`       | `/opt/IBM/InstallationManager`                      |
 | `profiled_path`          | `/opt/profile.d`                                    |
@@ -35,7 +35,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware
 
   vars:
-    websphere_version: 9.0.5.22
+    websphere_version: 9.0.5.23
     download_url: "https://myserver.com/was/repos"
     download_header: { 'Authorization': 'Basic EncodedString'}
 

--- a/roles/websphere/defaults/main.yml
+++ b/roles/websphere/defaults/main.yml
@@ -3,7 +3,7 @@
 iim_install_path: /opt/IBM/InstallationManager
 # websphere
 websphere_install_path: /opt/IBM/WebSphere/AppServer
-websphere_version: 9.0.5.22
+websphere_version: 9.0.5.23
 security_username: websphere
 # use encrypted password
 security_password: dummypassword

--- a/roles/websphere/vars/v8.5.5.27.yml
+++ b/roles/websphere/vars/v8.5.5.27.yml
@@ -1,0 +1,15 @@
+---
+websphere_pid: v85_8.5.5027.20250129_1123
+
+websphere_base_pid: com.ibm.websphere.ND.v85
+websphere_base_path: WAS/8.5.5ND
+websphere_base_archive_list:
+  - WAS_ND_V8.5.5_1_OF_3.zip
+  - WAS_ND_V8.5.5_2_OF_3.zip
+  - WAS_ND_V8.5.5_3_OF_3.zip
+
+websphere_fp_path: WAS/8.5.5Fixpacks/FP27
+websphere_fp_archive_list:
+  - 8.5.5-WS-WAS-FP027-part1.zip
+  - 8.5.5-WS-WAS-FP027-part2.zip
+  - 8.5.5-WS-WAS-FP027-part3.zip

--- a/roles/websphere/vars/v9.0.5.23.yml
+++ b/roles/websphere/vars/v9.0.5.23.yml
@@ -1,0 +1,17 @@
+---
+# FP Vars
+websphere_pid: v90_9.0.5023.20250307_1839
+websphere_fp_path: WAS/9.0.5Fixpacks
+websphere_fp_archive_list:
+  - 9.0.5-WS-WAS-FP023.zip
+
+# Base Vars
+websphere_base_pid: com.ibm.websphere.ND.v90
+websphere_base_path: WAS/9.0.5ND
+websphere_base_archive_list:
+  - was.repo.90500.nd.zip
+
+# Java Vars
+websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.40-linux-x64-installmgr.zip
+websphere_java_pid: com.ibm.java.jdk.v8
+websphere_java_home: java/8.0


### PR DESCRIPTION
Update to latest IBM Installation Manager - 1.9.301 
Update WebSphere and IBM HTTP Server to v9.0.5.23 - new yaml files 
Update WebSphere Liberty to v25.0.0.3 - new yaml files (Java8 and Java21) 
Update WebSphere and IBM HTTP Server with new V8.5.5 version - v8.5.5.27 - new yaml files 
Update READMEs
Update Molecule Tests
Update Galaxy file