### PR TITLE
Update OHS Conf file to include other Curam Portals

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.9.1
+version: 1.9.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ohs/templates/mod_wl_ohs.conf.j2
+++ b/roles/ohs/templates/mod_wl_ohs.conf.j2
@@ -13,7 +13,7 @@ LoadModule weblogic_module   "${PRODUCT_HOME}/modules/mod_wl_ohs.so"
     WLProxySSL ON
     WLSSLWallet "${ORACLE_INSTANCE}/config/fmwconfig/components/${COMPONENT_TYPE}/instances/${COMPONENT_NAME}/keystores/pluginWallet"
     WebLogicSSLVersion TLSv1_2
-    <LocationMatch "^/(console|CitizenPortal|CPMExternalNS|CPMExternalS|Curam|CuramBIRTViewer|CuramWS|CuramWS2|Rest|swagger)">
+    <LocationMatch "^/(console|CitizenPortal|CPMExternalNS|CPMExternalS|Curam|CuramBIRTViewer|CuramWS|CuramWS2|Rest|swagger|MDTWorkspace|SamplePublicAccess|NavigatorS)">
         WLSRequest on
         WebLogicHost {{ ansible_fqdn }}
         WebLogicPort {{ ohs_port }}


### PR DESCRIPTION
Update OHs Conf file to include other Curam Portals otherwise we cannot access MDTWorkspace and others added in this changeset