### PR TITLE
Support for WLS 14.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
           - ohs-v12.2.1.4-rockylinux9
           - weblogic-rockylinux8
           - weblogic-rockylinux9
+          - weblogic-1412-rockylinux8
+          - weblogic-1412-rockylinux9
           - oracle19c-rockylinux8
           - oracle19c-rockylinux9
           - iim-191-rockylinux8

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.9.2
+version: 1.9.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__weblogic-v14.1.2/converge.yml
+++ b/molecule/__weblogic-v14.1.2/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+
+  collections:
+    - merative.spm_middleware
+
+  vars:
+    weblogic_version: "14.1.2.0.250324"
+    # weblogic_installer_path: /opt/IBM/weblogic/WLS
+    download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}
+  roles:
+    - weblogic

--- a/molecule/__weblogic-v14.1.2/verify.yml
+++ b/molecule/__weblogic-v14.1.2/verify.yml
@@ -1,0 +1,44 @@
+---
+- name: Verify
+  hosts: all
+  pre_tasks:
+    - name: include defaults
+      include_vars: "../../roles/weblogic/defaults/main.yml"
+    - name: include vars
+      include_vars: "../../roles/weblogic/vars/v14.1.2.0.250324.yml"
+    - stat:
+        path: /opt/Props/AppServer.properties
+      register: boot_props
+    - name: Slurp profile.d
+      slurp:
+        src: /opt/profile.d/weblogic.sh
+      register: env_oracle_sh
+    - name: Slurp registry.xml
+      slurp:
+        src: /home/oracle/Oracle/Middleware/Oracle_Home/inventory/registry.xml
+      register: registry_xml
+    - name: Check OPatch version
+      shell: "grep {{ opatch_version }} {{ weblogic_home }}/OPatch/version.txt"
+      ignore_errors: True
+      register: opatch_version_flag
+      when: opatch_version is defined
+    - name: Check if patched with correct patch
+      become: yes
+      become_user: "{{ weblogic_user }}"
+      shell: "{{ weblogic_home }}/OPatch/opatch lspatches | grep -i {{ patch_number }}"
+      changed_when: False
+      when: patch_number is defined
+  tasks:
+    - name: Check that AppServer.properties exists
+      assert:
+        that: boot_props.stat.exists
+    - name: Check that environment file has been created correctly
+      assert:
+        that: "{{ 'MW_HOME=/home/oracle/Oracle/Middleware/Oracle_Home' in (env_oracle_sh['content'] | b64decode) }}"
+    - name: Check Weblogic Installed
+      assert:
+        that: "{{ 'distribution status=\"installed\" name=\"WebLogic Server\"' in (registry_xml['content'] | b64decode) }}"
+    - name: Check OPatch version
+      assert:
+        that: opatch_version_flag.rc == 0
+      when: opatch_version is defined

--- a/molecule/weblogic-1412-rockylinux8/molecule.yml
+++ b/molecule/weblogic-1412-rockylinux8/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux8
+    image: rockylinux:8
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    # volume_mounts:
+    #   - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__weblogic-v14.1.2/converge.yml
+    verify: ../__weblogic-v14.1.2/verify.yml

--- a/molecule/weblogic-1412-rockylinux9/molecule.yml
+++ b/molecule/weblogic-1412-rockylinux9/molecule.yml
@@ -1,0 +1,34 @@
+---
+driver:
+  name: docker
+  provider:
+    name: docker
+
+lint: |
+  set -e
+  yamllint .
+
+platforms:
+  - name: rockylinux9
+    image: rockylinux:9
+    dockerfile: ../_resources/Dockerfile.j2
+    pre_build_image: False
+    privileged: True
+    # volume_mounts:
+    #   - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      stderr_callback: debug
+      stdout_callback: debug
+  env:
+    ANSIBLE_FORCE_COLOR: 'true'
+  playbooks:
+    converge: ../__weblogic-v14.1.2/converge.yml
+    verify: ../__weblogic-v14.1.2/verify.yml

--- a/roles/weblogic/README.md
+++ b/roles/weblogic/README.md
@@ -4,7 +4,7 @@ The `weblogc` role will install Weblogic.
 
 ## Requirements
 
-* CentOS-7/8, Redhat 7.x/8.x
+* CentOS-7/8, Redhat 7.x/8.x/9.x
 
 ## Role Variables
 
@@ -19,16 +19,17 @@ The `weblogc` role will install Weblogic.
 | `weblogic_patch_path`     | Controller local path or relative to download_url |
 | `java_zip_path`           | Controller local path or relative to download_url |
 
-| ------------------------- | --------------------------------------------------- |
-| ** `weblogic_version` **  | `12.1.3.0.2`                                        |
-|                           | `12.1.3.0.210720`                                   |
-|                           | `12.2.1.4.210716`                                   |
-|                           | `14.1.1.0.220105`                                   |
-|                           | `14.1.1.0.240111`                                   |
-|                           | `14.1.1.0.240922`                                   |
-|                           | `14.1.1.0.250108`                                   |
-|                           | `14.1.1.0.250320`                                                    |
-| ------------------------- | --------------------------------------------------- |
+| ----------------------------------- | --------------------------------------------------- |
+| ** `weblogic_version - java8` **    | `12.1.3.0.2`                                        |
+|                                     | `12.1.3.0.210720`                                   |
+|                                     | `12.2.1.4.210716`                                   |
+|                                     | `14.1.1.0.220105`                                   |
+|                                     | `14.1.1.0.240111`                                   |
+|                                     | `14.1.1.0.240922`                                   |
+|                                     | `14.1.1.0.250108`                                   |
+|                                     | `14.1.1.0.250320`                                   |
+|  ** `weblogic_version - java21` **  | `14.1.1.0.250320`                                   |
+| ----------------------------------- | --------------------------------------------------- |
 
 ...
 
@@ -54,13 +55,15 @@ The version of the OPatch tool itself is also handed by the above tasks file.
 - hosts: servers
   roles:
     - role: merative.spm_middleware.weblogic
-      weblogic_version: 14.1.1.0.250320
+      weblogic_version - java8: 14.1.1.0.250320
+      weblogic_version - java21: 14.1.2.0.250324
 ```
 
 ## Note
 
 1. Default JDK version is 1.8.0_251. Required by Dev Team.
 2. We keep 12.1.3.0.2. This is not the latest version. Required by Dev Team.
+3. WebLogic now supports both Java8 - v12.2 and v14.1.1 and Java21 - v14.1.2
 
 ## License
 

--- a/roles/weblogic/vars/v14.1.2.0.250324.yml
+++ b/roles/weblogic/vars/v14.1.2.0.250324.yml
@@ -1,0 +1,11 @@
+---
+base_install_file: 'fmw_14.1.2.0.0_wls.jar'
+weblogic_version: 14.1.2
+opatch: 'p28186730_1394219_Generic.zip'
+opatch_version: 13.9.4.2.19
+patch: 'p37743913_141200_Generic.zip'
+patch_number: 37743913
+napply: False
+patch_folder: '37743913'
+java_archive_file: jdk-21.0.7_linux-x64_bin.tar.gz
+java_version_path: 'jdk-21.0.7'


### PR DESCRIPTION
Creating and introducing YAML files for Weblogic 14.1.2 (which uses Java21)

 - New YAML file for 14.1.2 (including new base installer, latest WLS patch, and latest Java21 JDK)
 - Added in molecule tests for WLS 14.1.2 on RHEL8 and RHEL9
 - Updated ReadME
 - Updated Galaxy file

Molecule tests have passed locally for RHEL 8 and RHEL 9.. No issues with the install and patching