### PR TITLE
IBM Quarterly FixPack Updates

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.10.5
+version: 1.10.6
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ihs-v85/converge.yml
+++ b/molecule/__ihs-v85/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 8.5.5.28
+    ihs_version: 8.5.5.29
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__ihs-v90/converge.yml
+++ b/molecule/__ihs-v90/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 9.0.5.26
+    ihs_version: 9.0.5.27
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty/converge.yml
+++ b/molecule/__liberty/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "25.0.0.12"
+    liberty_version: "26.0.0.3"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty21/converge.yml
+++ b/molecule/__liberty21/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "25.0.0.12-JDK21"
+    liberty_version: "26.0.0.3-JDK21"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v85/converge.yml
+++ b/molecule/__websphere-v85/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    websphere_version: 8.5.5.28
+    websphere_version: 8.5.5.29
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v90/converge.yml
+++ b/molecule/__websphere-v90/converge.yml
@@ -6,9 +6,9 @@
     - merative.spm_middleware
 
   vars:
-    iim_agent_version: 1.9.3004.20251123_2122
+    iim_agent_version: 1.10.1003.20250827_1041
     iim_install_path: /opt/IBM/InstallationManager
-    websphere_version: 9.0.5.26
+    websphere_version: 9.0.5.27
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/db2-121/converge.yml
+++ b/molecule/db2-121/converge.yml
@@ -9,6 +9,6 @@
     - db2
 
   vars:
-    db2_version: "12.1.3.0"
+    db2_version: "12.1.4.0"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}

--- a/molecule/db2-121/verify.yml
+++ b/molecule/db2-121/verify.yml
@@ -19,4 +19,4 @@
       assert:
         that:
           - db2level_cmd.rc == 0
-          - "'v12.1.3' in db2level_cmd.stdout"
+          - "'v12.1.4' in db2level_cmd.stdout"

--- a/roles/db2/README.md
+++ b/roles/db2/README.md
@@ -13,7 +13,7 @@ Ensure you update / override password variables prior to using the role.
 | Property Name             | Default value                                       |
 | ------------------------- | --------------------------------------------------- |
 | `db2_install_path`        | `/opt/IBM/db2`                                      |
-| `db2_version`             | `12.1.3.0`                                          |
+| `db2_version`             | `12.1.4.0`                                          |
 | `db2_product`             | `DB2_SERVER_EDITION`                                |
 | `db2_bypass_prereq_check` | `False`                                             |
 | ------------------------- | --------------------------------------------------- |
@@ -43,7 +43,7 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.db2
-      db2_version: 12.1.3.0
+      db2_version: 12.1.4.0
 ```
 
 ## License

--- a/roles/db2/vars/v12.1.4.0.yml
+++ b/roles/db2/vars/v12.1.4.0.yml
@@ -1,0 +1,4 @@
+---
+# paths can be relative to download_url or local
+db2_installer_path: DB2/12.1/v12.1.4_linuxx64_universal_fixpack.tar.gz
+db2_license_path: DB2/12.1/db2ese_u.lic

--- a/roles/ihs/README.md
+++ b/roles/ihs/README.md
@@ -13,18 +13,18 @@ NOTE: ihs_admin_pass should be changed after first installation.
 | `ihs_install_path`      | `/opt/IBM/HTTPServer`                               |
 | `plg_install_path`      | `/opt/IBM/WebSphere/Plugins`                        |
 | `wct_install_path`      | `/opt/IBM/WebSphere/Toolbox`                        |
-| `ihs_version`           | `9.0.5.26`                                           |
+| `ihs_version`           | `9.0.5.27`                                           |
 | `ihs_config_type`       | `local_distributed`                                 |
 | `ihs_admin_user`        | `wasadmin`                                          |
 | `ihs_admin_pass`        | `wasadmin`                                          |
 | ----------------------- | --------------------------------------------------- |
-| Version-specific:       | Values from `9.0.5.26`                               |
+| Version-specific:       | Values from `9.0.5.27`                               |
 | ----------------------- | --------------------------------------------------- |x  
 | `ihs_installer_archive_list` | `was.repo.90500.[ihs|plugins|wct].zip`         |
 | `ihs_fp_installer_path` | `WAS/9.0.5Fixpacks`                                 |
-| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP025.zip`           |
-| `ihs_pid`               | `v90~9.0.5026.20251114_1520`                        |
-| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.55-linux-x64-installmgr.zip` |
+| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP027.zip`           |
+| `ihs_pid`               | `v90~9.0.5027.20260306_2357`                        |
+| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.60-linux-x64-installmgr.zip` |
 | `ihs_java_pid`          | `com.ibm.java.jdk.v8`                               |
 | ----------------------- | --------------------------------------------------- |
 | `iim_install_path`      | `/opt/IBM/InstallationManager`                      |
@@ -53,7 +53,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware.iim
     - merative.spm_middleware.ihs
       vars:
-        - ihs_version: 9.0.5.26
+        - ihs_version: 9.0.5.27
         - download_url: "https://myserver.com/IHS/repos"
         - download_header: { 'Authorization': 'Basic EncodedString'}
 ```

--- a/roles/ihs/defaults/main.yml
+++ b/roles/ihs/defaults/main.yml
@@ -5,7 +5,7 @@ ihs_install_path: /opt/IBM/HTTPServer
 plg_install_path: /opt/IBM/WebSphere/Plugins
 wct_install_path: /opt/IBM/WebSphere/Toolbox
 
-ihs_version: 9.0.5.26
+ihs_version: 9.0.5.27
 
 ihs_config_type: local_distributed
 ihs_admin_user: wasadmin

--- a/roles/ihs/vars/v8.5.5.29.yml
+++ b/roles/ihs/vars/v8.5.5.29.yml
@@ -1,0 +1,19 @@
+---
+ihs_installer_path: WAS/8.5.5ND
+ihs_installer_archive_list:
+  - WAS_V8.5.5_SUPPL_1_OF_3.zip
+  - WAS_V8.5.5_SUPPL_2_OF_3.zip
+  - WAS_V8.5.5_SUPPL_3_OF_3.zip
+
+ihs_fp_installer_path: WAS/8.5.5Fixpacks/FP29
+ihs_fp_installer_archive_list:
+  - 8.5.5-WS-WASSupplements-FP029-part1.zip
+  - 8.5.5-WS-WASSupplements-FP029-part2.zip
+  - 8.5.5-WS-WASSupplements-FP029-part3.zip
+
+ihs_wct_installer_list:
+  - 8.5.5-WS-WCT-FP029-part1.zip
+  - 8.5.5-WS-WCT-FP029-part2.zip
+
+ihs_pid: v85_8.5.5029.20260128_1103
+ihs_base_pid: v85_8.5.5000.20130514_1044

--- a/roles/ihs/vars/v9.0.5.27.yml
+++ b/roles/ihs/vars/v9.0.5.27.yml
@@ -1,0 +1,16 @@
+---
+ihs_installer_path: WAS/9.0.5ND
+ihs_installer_archive_list:
+  - was.repo.90500.ihs.zip
+  - was.repo.90500.plugins.zip
+  - was.repo.90500.wct.zip
+
+ihs_fp_installer_path: WAS/9.0.5Fixpacks
+ihs_fp_installer_archive_list:
+  - 9.0.5-WS-IHSPLG-FP027.zip
+  - 9.0.5-WS-WCT-FP027.zip
+
+ihs_pid: v90_9.0.5027.20260306_2357
+
+ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.60-linux-x64-installmgr.zip
+ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/liberty/README.md
+++ b/roles/liberty/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) must already be installed in the target environ
 | Property Name           | Default value                                       |
 | ----------------------- | --------------------------------------------------- |
 | `liberty_install_path`  | `/opt/IBM/WebSphere/Liberty`                        |
-| `liberty_version`       | `25.0.0.12`                                         |
+| `liberty_version`       | `26.0.0.3`                                         |
 | `liberty_default_heapsize`  | `1024m`                                         |
 | `liberty_enable_verbose_gc` | `false`                                         |
 | `liberty_extra_jvm_options` | `[]`                                            |
@@ -37,7 +37,7 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.liberty
-      liberty_version: 25.0.0.12
+      liberty_version: 26.0.0.3
 ```
 
 ## License

--- a/roles/liberty/defaults/main.yml
+++ b/roles/liberty/defaults/main.yml
@@ -3,7 +3,7 @@ iim_install_path: /opt/IBM/InstallationManager
 
 liberty_install_path: /opt/IBM/WebSphere/Liberty
 
-liberty_version: 25.0.0.12
+liberty_version: 26.0.0.3
 
 jdk_version: 8.0
 

--- a/roles/liberty/vars/v26.0.0.3-JDK21.yml
+++ b/roles/liberty/vars/v26.0.0.3-JDK21.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/26.0.0.3-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 26.0.3.20260309_1102
+jdk_version: 21.0
+jdk_installation_way: unzip
+liberty_java_zip_path: Java/IBM/ibm-semeru-open-jdk_x64_linux_21.0.10.1.tar.gz

--- a/roles/liberty/vars/v26.0.0.3.yml
+++ b/roles/liberty/vars/v26.0.0.3.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/26.0.0.3-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 26.0.3.20260309_1102
+
+liberty_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.60-linux-x64-installmgr.zip
+liberty_java_pid: com.ibm.java.jdk.v8_8.0.8060.20260119_0831

--- a/roles/websphere/README.md
+++ b/roles/websphere/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) or higher must already be installed in the targ
 | Property Name            | Default value                                       |
 | ------------------------ | --------------------------------------------------- |
 | `websphere_install_path` | `/opt/IBM/WebSphere/AppServer`                      |
-| `websphere_version`      | `9.0.5.26`                                           |
+| `websphere_version`      | `9.0.5.27`                                           |
 | ------------------------ | --------------------------------------------------- |
 | `iim_install_path`       | `/opt/IBM/InstallationManager`                      |
 | `profiled_path`          | `/opt/profile.d`                                    |
@@ -35,7 +35,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware
 
   vars:
-    websphere_version: 9.0.5.26
+    websphere_version: 9.0.5.27
     download_url: "https://myserver.com/was/repos"
     download_header: { 'Authorization': 'Basic EncodedString'}
 

--- a/roles/websphere/defaults/main.yml
+++ b/roles/websphere/defaults/main.yml
@@ -3,7 +3,7 @@
 iim_install_path: /opt/IBM/InstallationManager
 # websphere
 websphere_install_path: /opt/IBM/WebSphere/AppServer
-websphere_version: 9.0.5.26
+websphere_version: 9.0.5.27
 security_username: websphere
 # use encrypted password
 security_password: dummypassword

--- a/roles/websphere/vars/v8.5.5.29.yml
+++ b/roles/websphere/vars/v8.5.5.29.yml
@@ -1,0 +1,15 @@
+---
+websphere_pid: v85_8.5.5029.20260128_1103
+
+websphere_base_pid: com.ibm.websphere.ND.v85
+websphere_base_path: WAS/8.5.5ND
+websphere_base_archive_list:
+  - WAS_ND_V8.5.5_1_OF_3.zip
+  - WAS_ND_V8.5.5_2_OF_3.zip
+  - WAS_ND_V8.5.5_3_OF_3.zip
+
+websphere_fp_path: WAS/8.5.5Fixpacks/FP29
+websphere_fp_archive_list:
+  - 8.5.5-WS-WAS-FP029-part1.zip
+  - 8.5.5-WS-WAS-FP029-part2.zip
+  - 8.5.5-WS-WAS-FP029-part3.zip

--- a/roles/websphere/vars/v9.0.5.27.yml
+++ b/roles/websphere/vars/v9.0.5.27.yml
@@ -1,0 +1,17 @@
+---
+# FP Vars
+websphere_pid: v90_9.0.5027.20260306_2357
+websphere_fp_path: WAS/9.0.5Fixpacks
+websphere_fp_archive_list:
+  - 9.0.5-WS-WAS-FP027.zip
+
+# Base Vars
+websphere_base_pid: com.ibm.websphere.ND.v90
+websphere_base_path: WAS/9.0.5ND
+websphere_base_archive_list:
+  - was.repo.90500.nd.zip
+
+# Java Vars
+websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.60-linux-x64-installmgr.zip
+websphere_java_pid: com.ibm.java.jdk.v8
+websphere_java_home: java/8.0


### PR DESCRIPTION
Bump collection and middleware component versions and add new role vars.

- galaxy: bump collection version to 1.10.6.
- IHS: update to 8.5.5.29 and 9.0.5.27 (molecule converge, role defaults, README) and add vars files roles/ihs/vars/v8.5.5.29.yml and roles/ihs/vars/v9.0.5.27.yml (installer, FP, PID and Java entries).
- WebSphere: update to 8.5.5.29 and 9.0.5.27 (molecule, defaults, README) and add roles/websphere/vars/v8.5.5.29.yml and roles/websphere/vars/v9.0.5.27.yml.
- Liberty: update to 26.0.0.3 (including JDK21 variant) in molecule, defaults and README; add roles/liberty/vars/v26.0.0.3.yml and v26.0.0.3-JDK21.yml with installer/FP/PID/Java settings.
- DB2: bump to 12.1.4.0 (molecule converge and verify, README) and add roles/db2/vars/v12.1.4.0.yml with installer and license paths; update verify expected output to v12.1.4.

These changes keep test scenarios, role defaults, and documentation in sync with new middleware fixpacks and installer artifacts.