### PR TITLE
Update middleware versions and add vars files for latest Oracle FixPacks

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.10.7
+version: 1.10.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ohs-v12.2.1.4/converge.yml
+++ b/molecule/__ohs-v12.2.1.4/converge.yml
@@ -32,14 +32,14 @@
         name: weblogic
       vars:
         ansible_python_interpreter: /usr/bin/python3
-        weblogic_version: "14.1.1.0.251223"
+        weblogic_version: "14.1.1.0.260403"
 
     - name: include ohs
       include_role:
         name: ohs
       vars:
         ansible_python_interpreter: /usr/bin/python3
-        ohs_version: "12.2.1.4.260116"
+        ohs_version: "12.2.1.4.260312"
   vars:
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}

--- a/molecule/__ohs-v12.2.1.4/verify.yml
+++ b/molecule/__ohs-v12.2.1.4/verify.yml
@@ -4,7 +4,7 @@
 
   pre_tasks:
     - name: include vars
-      include_vars: "../../roles/ohs/vars/v12.2.1.4.260116.yml"
+      include_vars: "../../roles/ohs/vars/v12.2.1.4.260312.yml"
 
     - name: include default
       include_vars: "../../roles/ohs/defaults/main.yml"

--- a/molecule/__ohs-v14.1.2/converge.yml
+++ b/molecule/__ohs-v14.1.2/converge.yml
@@ -32,14 +32,14 @@
         name: weblogic
       vars:
         ansible_python_interpreter: /usr/bin/python3
-        weblogic_version: "14.1.2.0.251223"
+        weblogic_version: "14.1.2.0.260403"
 
     - name: include ohs
       include_role:
         name: ohs
       vars:
         ansible_python_interpreter: /usr/bin/python3
-        ohs_version: "14.1.2.0.260115"
+        ohs_version: "14.1.2.0.260316"
   vars:
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}

--- a/molecule/__ohs-v14.1.2/verify.yml
+++ b/molecule/__ohs-v14.1.2/verify.yml
@@ -4,7 +4,7 @@
 
   pre_tasks:
     - name: include vars
-      include_vars: "../../roles/ohs/vars/v14.1.2.0.260115.yml"
+      include_vars: "../../roles/ohs/vars/v14.1.2.0.260316.yml"
 
     - name: include default
       include_vars: "../../roles/ohs/defaults/main.yml"

--- a/molecule/__oracle-v19c/converge.yml
+++ b/molecule/__oracle-v19c/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    oracle_version: 19.30.0.0.0
+    oracle_version: 19.31.0.0.0
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__oracle-v19c/verify.yml
+++ b/molecule/__oracle-v19c/verify.yml
@@ -6,7 +6,7 @@
   vars:
     oracle_home: /opt/oracle/product/19c/dbhome_1
     oracle_sid: orcl
-    oracle_version: 19.30.0.0.0
+    oracle_version: 19.31.0.0.0
 
   pre_tasks:
     - name: Check if DB exists

--- a/molecule/__oracle-v26ai/converge.yml
+++ b/molecule/__oracle-v26ai/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    oracle_version: 23.26.1.0.0
+    oracle_version: 23.26.2.0.0
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__oracle-v26ai/verify.yml
+++ b/molecule/__oracle-v26ai/verify.yml
@@ -6,7 +6,7 @@
   vars:
     oracle_home: /opt/oracle/product/26ai/dbhome_1
     oracle_sid: orcl
-    oracle_version: 23.26.1.0.0
+    oracle_version: 23.26.2.0.0
     oracle_family: 26ai
 
   pre_tasks:

--- a/molecule/__weblogic-v12.2/converge.yml
+++ b/molecule/__weblogic-v12.2/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    weblogic_version: "12.2.1.4.251223"
+    weblogic_version: "12.2.1.4.260403"
     # weblogic_installer_path: /opt/IBM/weblogic/WLS
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/molecule/__weblogic-v12.2/verify.yml
+++ b/molecule/__weblogic-v12.2/verify.yml
@@ -5,7 +5,7 @@
     - name: include defaults
       include_vars: "../../roles/weblogic/defaults/main.yml"
     - name: include vars
-      include_vars: "../../roles/weblogic/vars/v12.2.1.4.251223.yml"
+      include_vars: "../../roles/weblogic/vars/v12.2.1.4.260403.yml"
     - stat:
         path: /opt/Props/AppServer.properties
       register: boot_props

--- a/molecule/__weblogic-v14.1.2/converge.yml
+++ b/molecule/__weblogic-v14.1.2/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    weblogic_version: "14.1.2.0.251223"
+    weblogic_version: "14.1.2.0.260403"
     # weblogic_installer_path: /opt/IBM/weblogic/WLS
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/molecule/__weblogic-v14.1.2/verify.yml
+++ b/molecule/__weblogic-v14.1.2/verify.yml
@@ -5,7 +5,7 @@
     - name: include defaults
       include_vars: "../../roles/weblogic/defaults/main.yml"
     - name: include vars
-      include_vars: "../../roles/weblogic/vars/v14.1.2.0.251223.yml"
+      include_vars: "../../roles/weblogic/vars/v14.1.2.0.260403.yml"
     - stat:
         path: /opt/Props/AppServer.properties
       register: boot_props

--- a/molecule/__weblogic-v14.1/converge.yml
+++ b/molecule/__weblogic-v14.1/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    weblogic_version: "14.1.1.0.251223"
+    weblogic_version: "14.1.1.0.260403"
     # weblogic_installer_path: /opt/IBM/weblogic/WLS
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}

--- a/molecule/__weblogic-v14.1/verify.yml
+++ b/molecule/__weblogic-v14.1/verify.yml
@@ -5,7 +5,7 @@
     - name: include defaults
       include_vars: "../../roles/weblogic/defaults/main.yml"
     - name: include vars
-      include_vars: "../../roles/weblogic/vars/v14.1.1.0.251223.yml"
+      include_vars: "../../roles/weblogic/vars/v14.1.1.0.260403.yml"
     - stat:
         path: /opt/Props/AppServer.properties
       register: boot_props

--- a/roles/ohs/README.md
+++ b/roles/ohs/README.md
@@ -14,7 +14,7 @@ NOTE: Update these default usernames and passwords after the initial installatio
 
 | Property Name             | Default value                                       |
 | ------------------------- | --------------------------------------------------- |
-| `ohs_version`             | `12.2.1.4.260116`                                   |
+| `ohs_version`             | `12.2.1.4.260312`                                   |
 | `ohs_user`                | `oracle`                                            |
 | `ohs_admin_password`      | `password1`                                         |
 | `ohs_group`               | `oinstall`                                          |
@@ -31,6 +31,11 @@ NOTE: Update these default usernames and passwords after the initial installatio
 | `profiled_path`           | `/opt/profile.d`                                    |
 | ------------------------- | --------------------------------------------------- |
 
+| ----------------------------------- | --------------------------------------------------- |
+| ** `ohs_version - java8` **         | `12.2.1.4.260312`                                   |
+| ** `ohs_version - java21` **        | `14.1.2.0.260316`                                   |
+| ----------------------------------- | --------------------------------------------------- |
+
 ## Dependencies
 
 Although the role can be used independently, it is expected that Weblogic is already installed on the host and will not function correctly without it.
@@ -41,7 +46,8 @@ Although the role can be used independently, it is expected that Weblogic is alr
 - hosts: all
   roles:
     - role: merative.spm_middleware.ohs
-      ohs_version: 12.2.1.4.260116
+      ohs_version - java8: 12.2.1.4.260312
+      ohs_version - java21: 14.1.2.0.260316
 ```
 ## License
 

--- a/roles/ohs/vars/v12.2.1.4.260312.yml
+++ b/roles/ohs/vars/v12.2.1.4.260312.yml
@@ -1,0 +1,33 @@
+---
+# Base Information
+ohs_version_folder: 12.2.1
+base_version: 12.2.1.4.0
+base_installer: fmw_12.2.1.4.0_ohs_linux64.bin
+base_installer_path: "OHS/12.2.1/fmw_12.2.1.4.0_ohs_linux64.bin"
+
+# Upgrade Information
+upgrade19c_version: 12.2.1.19.0
+upgrade19c_installer_path: "OHS/12.2.1/19cUpgrade"
+upgrade19c_installer_zip: "p34761383_122140_Linux-x86-64.zip"
+upgrade19c_installer: fmw_12.2.1.19.0_dbclient_linux64.bin
+upgrade19c_installer_folder: 34761383
+
+# Patch information
+ohs_version: 12.2.1.4.260312
+patches:
+  - filename: "OHS/{{ ohs_version_folder }}/p39073998_122140_Linux-x86-64.zip"
+    number: 39073998
+  - filename: "OHS/{{ ohs_version_folder }}/p35333510_122140_Linux-x86-64.zip"
+    number: 35037811
+
+# OPatch Information
+opatch_filename_path: "WLS/Patches/p28186730_1394223_Generic.zip"
+opatch_version: 13.9.4.2.23
+opatch_folder: 6880880
+
+# JDK Information
+java_zip_path: 'WLS/jdk-8u491-linux-x64.tar.gz'
+java_version_path: 'jdk1.8.0_491'
+jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
+
+template_jar: "ohs_standalone_template.jar"

--- a/roles/ohs/vars/v14.1.2.0.260316.yml
+++ b/roles/ohs/vars/v14.1.2.0.260316.yml
@@ -1,0 +1,24 @@
+---
+# Base Information
+ohs_version_folder: 14.1.2
+base_version: "14.1.2.0.0"
+base_installer: fmw_14.1.2.0.0_ohs_linux64.bin
+base_installer_path: "OHS/14.1.2/fmw_14.1.2.0.0_ohs_linux64.bin"
+
+# Patch information
+ohs_version: 14.1.2.0.260316
+patches:
+  - filename: "OHS/{{ ohs_version_folder }}/p39086822_141200_Linux-x86-64.zip"
+    number: 39086822
+
+# OPatch Information
+opatch_filename_path: "WLS/Patches/p28186730_1394223_Generic.zip"
+opatch_version: 13.9.4.2.23
+opatch_folder: 6880880
+
+# JDK Information
+java_zip_path: 'WLS/jdk-21.0.11_linux-x64_bin.tar.gz'
+java_version_path: 'jdk-21.0.11'
+jdk_folder: "{{ ohs_home }}/oracle_common/jdk"
+
+template_jar: "ohs_standalone_template.jar"

--- a/roles/oracle/README.md
+++ b/roles/oracle/README.md
@@ -10,7 +10,7 @@ The `oracle` role will install Oracle Database EE Single Instance.
 
 | Property Name             | Default value                                       |
 | ------------------------- | --------------------------------------------------- |
-| `oracle_version`          | `19.30.0.0.0`                                       |
+| `oracle_version`          | `19.31.0.0.0`                                       |
 | `oracle_base`             | `/opt/oracle`                                       |
 | `oracle_home`             | `/opt/oracle/product/<oracle_family>/dbhome_1`                  |
 | `oracle_inventory`        | `/opt/Oracle/oraInventory`                          |
@@ -32,6 +32,11 @@ The `oracle` role will install Oracle Database EE Single Instance.
 | ------------------------- | --------------------------------------------------- |
 | `profiled_path`           | `/opt/profile.d`                                    |
 
+| ----------------------------------- | --------------------------------------------------- |
+| ** `oracle_version` **              | `19.31.0.0.0`                                   |
+|                                     | `23.36.2.0.0`                                   |
+| ----------------------------------- | --------------------------------------------------- |
+
 ## Dependencies
 
 None
@@ -42,7 +47,8 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.oracle
-      oracle_version: 19.30.0.0.0
+      oracle_version: 19.31.0.0.0
+      oracle_version: 23.26.2.0.0
 
 ## License
 

--- a/roles/oracle/defaults/main.yml
+++ b/roles/oracle/defaults/main.yml
@@ -7,7 +7,7 @@ travis_build: "{{ lookup('env', 'CI') }}"
 travis_flags: "{{'-force -ignoresysprereqs -ignoreprereq' if lookup('env', 'CI') is defined else ''}}"
 
 # Oracle config
-oracle_version: 19.30.0.0.0
+oracle_version: 19.31.0.0.0
 oracle_family: "{{ oracle_version.split('.') | first }}c"
 oracle_base: /opt/oracle
 oracle_home: "/opt/oracle/product/{{ oracle_family }}/dbhome_1"

--- a/roles/oracle/vars/v19.31.0.0.0.yml
+++ b/roles/oracle/vars/v19.31.0.0.0.yml
@@ -1,0 +1,17 @@
+---
+# prereq installers
+prereqs_installer_7: https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/oracle-database-preinstall-19c-1.0-1.el7.x86_64.rpm
+prereqs_installer_8: https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-19c-1.0-2.el8.x86_64.rpm
+prereqs_installer: "{{ prereqs_installer_7 if ansible_distribution_major_version=='7' else prereqs_installer_8 }}"
+# base installer values
+base_version: 19.3.0.0.0
+base_installer: oracle-database-ee-19c-1.0-1.x86_64.rpm
+# patch values
+patch_filename: p39034528_190000_Linux-x86-64.zip
+patch_number: 39034528  # used for directory
+# opatch values
+opatch_filename: p6880880_190000_Linux-x86-64.zip
+opatch_version: 12.2.0.1.51
+# jdkpatch values
+jdk_patch_filename: p38930593_190000_Linux-x86-64.zip
+jdk_patch_number: 38930593 # used for directory

--- a/roles/oracle/vars/v23.26.2.0.0.yml
+++ b/roles/oracle/vars/v23.26.2.0.0.yml
@@ -1,0 +1,20 @@
+---
+# prereq installers
+prereqs_installer_8: https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-ai-database-preinstall-26ai-1.0-1.el8.x86_64.rpm
+prereqs_installer_9: https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/getPackage/oracle-ai-database-preinstall-26ai-1.0-1.el9.x86_64.rpm
+prereqs_installer: "{{ prereqs_installer_8 if ansible_distribution_major_version=='8' else prereqs_installer_9 }}"
+# base installer values
+base_version: 23.26.1.0.0
+base_installer: oracle-ai-database-ee-26ai-1.0-1.el9.x86_64.rpm
+# patch values
+patch_filename: p39093711_230000_Linux-x86-64.zip
+patch_number: 39093711  # used for directory
+# opatch values
+opatch_filename: p6880880_230000_Linux-x86-64.zip
+opatch_version: 12.2.0.1.51
+# jdk patch values
+#jdk_patch_filename: p38245243_190000_Linux-x86-64.zip
+#jdk_patch_number: 38245243 # used for directory
+# 26ai specific configurations
+oracle_family: "26ai"
+sql_username: c##curam

--- a/roles/weblogic/README.md
+++ b/roles/weblogic/README.md
@@ -20,9 +20,9 @@ The `weblogc` role will install Weblogic.
 | `java_zip_path`           | Controller local path or relative to download_url |
 
 | ----------------------------------- | --------------------------------------------------- |
-| ** `weblogic_version - java8` **    | `12.2.1.4.251223`                                   |
-|                                     | `14.1.1.0.251223`                                   |
-|  ** `weblogic_version - java21` **  | `14.1.2.0.251223`                                   |
+| ** `weblogic_version - java8` **    | `12.2.1.4.260403`                                   |
+|                                     | `14.1.1.0.260403`                                   |
+|  ** `weblogic_version - java21` **  | `14.1.2.0.260403`                                   |
 | ----------------------------------- | --------------------------------------------------- |
 
 ...
@@ -49,9 +49,9 @@ The version of the OPatch tool itself is also handed by the above tasks file.
 - hosts: servers
   roles:
     - role: merative.spm_middleware.weblogic
-      weblogic_version - java8: 12.2.1.4.251223
-      weblogic_version - java8: 14.1.1.0.251223
-      weblogic_version - java21: 14.1.2.0.251223
+      weblogic_version - java8: 12.2.1.4.260403
+      weblogic_version - java8: 14.1.1.0.260403
+      weblogic_version - java21: 14.1.2.0.260403
 ```
 
 ## Note

--- a/roles/weblogic/defaults/main.yml
+++ b/roles/weblogic/defaults/main.yml
@@ -5,7 +5,7 @@ weblogic_group: 'oinstall'
 weblogic_os_user_pass: 'oracle'
 weblogic_base: '/home/oracle'
 # If not passed in, use this default value
-weblogic_version: '14.1.2.0.251223'
+weblogic_version: '14.1.2.0.260403'
 inv_loc: '/opt/Oracle/oraInventory'
 jdk_folder: '/usr/java'
 # Common paths and names

--- a/roles/weblogic/vars/v12.2.1.4.260403.yml
+++ b/roles/weblogic/vars/v12.2.1.4.260403.yml
@@ -1,0 +1,15 @@
+---
+# base install file
+base_install_file: 'fmw_12.2.1.4.0_wls.jar'
+weblogic_version: 12.2
+# opatch version - 13.9.4.2.23
+opatch: 'p28186730_1394223_Generic.zip'
+opatch_version: 13.9.4.2.23
+# wls version - 12.2.1.4.260403
+patch: 'p39163907_122140_Generic.zip'
+patch_number: 39163907
+napply: false
+patch_folder: '39163907'
+# jdk version - 1.8.0_491
+java_archive_file: jdk-8u491-linux-x64.tar.gz
+java_version_path: 'jdk1.8.0_491'

--- a/roles/weblogic/vars/v14.1.1.0.260403.yml
+++ b/roles/weblogic/vars/v14.1.1.0.260403.yml
@@ -1,0 +1,15 @@
+---
+# base install file
+base_install_file: 'fmw_14.1.1.0.0_wls.jar'
+weblogic_version: 14.1
+# opatch version - 13.9.4.2.23
+opatch: 'p28186730_1394223_Generic.zip'
+opatch_version: 13.9.4.2.23
+# wls version - 14.1.1.0.260403
+patch: 'p39164443_141100_Generic.zip'
+patch_number: 39164443
+napply: False
+patch_folder: '39164443'
+# jdk version - 1.8.0_491
+java_archive_file: jdk-8u491-linux-x64.tar.gz
+java_version_path: 'jdk1.8.0_491'

--- a/roles/weblogic/vars/v14.1.2.0.260403.yml
+++ b/roles/weblogic/vars/v14.1.2.0.260403.yml
@@ -1,0 +1,15 @@
+---
+# base install file
+base_install_file: 'fmw_14.1.2.0.0_wls.jar'
+weblogic_version: 14.1.2
+# opatch version - 13.9.4.2.23
+opatch: 'p28186730_1394223_Generic.zip'
+opatch_version: 13.9.4.2.23
+# wls version - 14.1.2.0.260403
+patch: 'p39164253_141200_Generic.zip'
+patch_number: 39164253
+napply: False
+patch_folder: '39164253'
+# jdk version - 21.0.11
+java_archive_file: jdk-21.0.11_linux-x64_bin.tar.gz
+java_version_path: 'jdk-21.0.11'


### PR DESCRIPTION
Bump collection and component versions and add corresponding variable files.

galaxy.yml bumped to 1.10.8.
Updated molecule converge/verify scenarios to reference new WebLogic, OHS, and Oracle patch versions (weblogic 12.2.1.4/14.1.1/14.1.2 -> 260403 series, ohs -> 12.2.1.4.260312 and 14.1.2.0.260316, oracle -> 19.31.0.0.0 and 23.26.2.0.0). Added new role vars files for roles/ohs, roles/oracle, and roles/weblogic reflecting installer/patch/JDK details for these releases, and updated role defaults and READMEs to match the new versions.