### PR TITLE
Add in targeted CleanUp tasks to each role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.10.8
+version: 1.10.9
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/db2/tasks/activate.yml
+++ b/roles/db2/tasks/activate.yml
@@ -17,8 +17,3 @@
 
 - name: Apply license
   command: "{{ db2_install_path }}/adm/db2licm -a {{ target_lic_file.dest }}"
-
-- name: Cleanup
-  file:
-    path: "{{ target_lic_file.dest }}"
-    state: absent

--- a/roles/db2/tasks/cleanup.yml
+++ b/roles/db2/tasks/cleanup.yml
@@ -1,0 +1,20 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup DB2Installer directory
+  file:
+    path: /tmp/DB2Installer
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup db2 directory
+  file:
+    path: /tmp/db2
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup db2server license file
+  file:
+    path: /tmp/db2server.lic
+    state: absent
+  ignore_errors: yes

--- a/roles/db2/tasks/install.yml
+++ b/roles/db2/tasks/install.yml
@@ -148,10 +148,4 @@
   retries: 50
   delay: 30
 
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - "{{ installer_dir.path }}"
-    - "{{ db2_installer.dest }}"
+

--- a/roles/db2/tasks/main.yml
+++ b/roles/db2/tasks/main.yml
@@ -50,3 +50,8 @@
 
 - name: Setup profile
   include_tasks: dot_profile.yml
+
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/ihs/tasks/cleanup.yml
+++ b/roles/ihs/tasks/cleanup.yml
@@ -1,0 +1,26 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup repo-zips directory
+  file:
+    path: /tmp/repo-zips
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup repo directory
+  file:
+    path: /tmp/repo
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup fp directory
+  file:
+    path: /tmp/fp
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup wct directory
+  file:
+    path: /tmp/wct
+    state: absent
+  ignore_errors: yes

--- a/roles/ihs/tasks/main.yml
+++ b/roles/ihs/tasks/main.yml
@@ -22,11 +22,7 @@
 - name: Configure IHS
   include_tasks: configure.yml
 
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/fp
-    - /tmp/wct
-    - /tmp/repo-zips
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/iim/tasks/cleanup.yml
+++ b/roles/iim/tasks/cleanup.yml
@@ -1,0 +1,15 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup iim temporary directory (Linux/MacOS)
+  file:
+    path: /tmp/iim
+    state: absent
+  ignore_errors: yes
+  when: ansible_os_family != "Windows"
+
+- name: Cleanup iim temporary directory (Windows)
+  win_file:
+    path: C:\Temp\iim
+    state: absent
+  when: ansible_os_family == "Windows"

--- a/roles/iim/tasks/darwin.yml
+++ b/roles/iim/tasks/darwin.yml
@@ -45,9 +45,3 @@
     mode: 0755
     recurse: yes
   become: yes
-
-- name: Delete temporary directory
-  file:
-    path: "{{ tmp_dir.path }}"
-    state: absent
-  become: yes

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -36,9 +36,3 @@
     chdir: "{{ tmp_dir.path }}"
     creates: "{{ iim_install_path }}"
   become: yes
-
-- name: Delete temporary directory
-  file:
-    path: "{{ tmp_dir.path }}"
-    state: absent
-  become: yes

--- a/roles/iim/tasks/main.yml
+++ b/roles/iim/tasks/main.yml
@@ -18,3 +18,8 @@
   include_tasks:
     file: "{{ ansible_os_family | lower }}.yml"
   when: (linux_iim_dir.stat is defined and not linux_iim_dir.stat.exists) or (win_iim_dir.stat is defined and not win_iim_dir.stat.exists)
+
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/iim/tasks/windows.yml
+++ b/roles/iim/tasks/windows.yml
@@ -30,8 +30,3 @@
   win_command: installc.exe -acceptLicense -iD {{ iim_install_path }}
   args:
     chdir: "{{ tmp_dir.path }}"
-
-- name: Delete temporary directory
-  win_file:
-    path: "{{ tmp_dir.path }}"
-    state: absent

--- a/roles/liberty/tasks/base_install.yml
+++ b/roles/liberty/tasks/base_install.yml
@@ -31,11 +31,3 @@
     path: "{{ liberty_install_path }}"
     repo: /tmp/repo
     state: present
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/repo
-    - /tmp/repo.zip

--- a/roles/liberty/tasks/cleanup.yml
+++ b/roles/liberty/tasks/cleanup.yml
@@ -1,0 +1,44 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup repo directory
+  file:
+    path: /tmp/repo
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup repo zip file
+  file:
+    path: /tmp/repo.zip
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup fprepo directory
+  file:
+    path: /tmp/fprepo
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup fprepo zip file
+  file:
+    path: /tmp/fprepo.zip
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup jdkrepo directory
+  file:
+    path: /tmp/jdkrepo
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup jdkrepo zip file
+  file:
+    path: /tmp/jdkrepo.zip
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup JDK zip file
+  file:
+    path: /tmp/jdk.zip
+    state: absent
+  ignore_errors: yes

--- a/roles/liberty/tasks/jdk_install.yml
+++ b/roles/liberty/tasks/jdk_install.yml
@@ -1,33 +1,33 @@
 ---
 - name: Download repo
   get_url:
-    dest: /tmp/fprepo.zip
-    url: "{{ download_url }}/{{ liberty_fp_path }}"
+    dest: /tmp/jdkrepo.zip
+    url: "{{ download_url }}/{{ liberty_java_path }}"
     headers: "{{ download_header }}"
   when: download_url is defined
 
 - name: Create repo directory
   file:
-    path: /tmp/fprepo
+    path: /tmp/jdkrepo
     state: directory
 
 - name: Copy Liberty fixpack repo
   copy:
-    src: "{{ liberty_fp_path }}"
-    dest: "/tmp/fprepo.zip"
+    src: "{{ liberty_java_path }}"
+    dest: "/tmp/jdkrepo.zip"
   when: download_url is not defined
 
 - name: Extract repo
   unarchive:
-    src: /tmp/fprepo.zip
-    dest: /tmp/fprepo
+    src: /tmp/jdkrepo.zip
+    dest: /tmp/jdkrepo
     remote_src: yes
-    creates: /tmp/fprepo/repository.config
+    creates: /tmp/jdkrepo/repository.config
 
 - name: Install package
   iim_package:
     iim_path: "{{ iim_install_path }}"
     product_id: "{{ pack_id }}"
     path: "{{ liberty_install_path }}"
-    repo: /tmp/fprepo
+    repo: /tmp/jdkrepo
     state: present

--- a/roles/liberty/tasks/main.yml
+++ b/roles/liberty/tasks/main.yml
@@ -19,18 +19,27 @@
   when: not iim_info.exact_installed
 
 - name: Install Java (iim way)
-  include_tasks: fixpack_install.yml
+  include_tasks: jdk_install.yml
   vars:
-    liberty_fp_path: "{{ liberty_java_zip_path }}"
+    liberty_java_path: "{{ liberty_java_zip_path }}"
     pack_id: "{{ liberty_java_pid }}"
   when: (not iim_info.exact_installed) and ( jdk_installation_way is undefined )
+
+- name: Check if JDK already installed (unzip way)
+  stat:
+    path: "{{ liberty_install_path }}/java/{{ jdk_version }}/bin/java"
+  register: jdk_unzip_installed
+  when: jdk_installation_way is defined
 
 - name: Download JDK (unzip way)
   get_url:
     dest: /tmp/jdk.zip
     url: "{{ download_url }}/{{ liberty_java_zip_path }}"
     headers: "{{ download_header }}"
-  when: (download_url is defined) and ( jdk_installation_way is defined )
+  when:
+    - download_url is defined
+    - jdk_installation_way is defined
+    - not (jdk_unzip_installed.stat is defined and jdk_unzip_installed.stat.exists)
 
 - name: Prepare Open JDK Folder (unzip way)
   file:
@@ -38,16 +47,20 @@
     state: directory
     owner: root
     group: root
-  when: jdk_installation_way is defined
+  when:
+    - jdk_installation_way is defined
+    - not (jdk_unzip_installed.stat is defined and jdk_unzip_installed.stat.exists)
 
 - name: Install Java (unzip way)
   unarchive:
     src: /tmp/jdk.zip
     dest: "{{ liberty_install_path }}/java/{{ jdk_version }}"
-    creates: "{{ liberty_install_path }}/java/{{ jdk_version }}/repository.config"
+    creates: "{{ liberty_install_path }}/java/{{ jdk_version }}/bin/java"
     extra_opts: [--strip-components=1]
     remote_src: yes
-  when: jdk_installation_way is defined
+  when:
+    - jdk_installation_way is defined
+    - not (jdk_unzip_installed.stat is defined and jdk_unzip_installed.stat.exists)
 
 - name: Create /opt/Props
   file:
@@ -71,3 +84,8 @@
     src: jvm.options.j2
     dest: "{{ liberty_install_path }}/usr/shared/jvm.options"
     mode: 0644
+
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/ohs/tasks/19cupgrade.yml
+++ b/roles/ohs/tasks/19cupgrade.yml
@@ -57,13 +57,3 @@
   become: yes
   become_user: "{{ ohs_user }}"
   command: "{{ ohs_installer_loc }}/upgrade19cInstaller/{{ upgrade19c_installer_folder }}/{{ upgrade19c_installer }} -ignoreSysPrereqs -invPtrLoc {{ ohs_home }}/oraInst.loc -silent ORACLE_HOME={{ ohs_home }}"
-
-- name: Cleanup
-  file:
-    path: "{{ ohs_installer_loc }}/upgrade19cInstaller"
-    state: absent
-
-- name: Cleanup
-  file:
-    path: "{{ ohs_installer_loc }}/19cUpgrade"
-    state: absent

--- a/roles/ohs/tasks/base_install.yml
+++ b/roles/ohs/tasks/base_install.yml
@@ -113,8 +113,3 @@
   become: yes
   become_user: "{{ ohs_user }}"
   command: "{{ ohs_installer_loc }}/baseInstaller -ignoreSysPrereqs -silent -responseFile {{ ohs_installer_loc }}/ohs_install.rsp"
-
-- name: Cleanup
-  file:
-    path: "{{ ohs_installer_loc }}/baseInstaller"
-    state: absent

--- a/roles/ohs/tasks/cleanup.yml
+++ b/roles/ohs/tasks/cleanup.yml
@@ -1,0 +1,76 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup base installer
+  file:
+    path: "{{ ohs_installer_loc }}/baseInstaller"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup 19c upgrade installer directory
+  file:
+    path: "{{ ohs_installer_loc }}/19cUpgrade"
+    state: absent
+  when: upgrade19c_version is defined
+  ignore_errors: yes
+
+- name: Cleanup 19c upgrade extracted directory
+  file:
+    path: "{{ ohs_installer_loc }}/upgrade19cInstaller"
+    state: absent
+  when: upgrade19c_version is defined
+  ignore_errors: yes
+
+- name: Cleanup Java installer
+  file:
+    path: "{{ ohs_installer_loc }}/java-repo.zip"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup OPatch file
+  file:
+    path: "/tmp/patch-repo.zip"
+    state: absent
+  when: opatch_filename_path is defined
+  ignore_errors: yes
+
+- name: Cleanup extracted OPatch folder
+  file:
+    path: "{{ ohs_installer_loc }}/{{ opatch_folder }}"
+    state: absent
+  when: opatch_folder is defined
+  ignore_errors: yes
+
+- name: Cleanup patch zip files
+  file:
+    path: "/tmp/{{ item.filename }}"
+    state: absent
+  loop: "{{ patches }}"
+  when: patches is defined
+  ignore_errors: yes
+
+- name: Cleanup extracted patch directories
+  file:
+    path: "/tmp/{{ item.number }}"
+    state: absent
+  loop: "{{ patches }}"
+  when: patches is defined
+  ignore_errors: yes
+
+- name: Cleanup OHS patches directory
+  file:
+    path: /tmp/ohsPatches
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup OHS temp directory
+  file:
+    path: /tmp/OHS
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup repo.zip (if exists)
+  file:
+    path: /tmp/repo.zip
+    state: absent
+  ignore_errors: yes

--- a/roles/ohs/tasks/main.yml
+++ b/roles/ohs/tasks/main.yml
@@ -60,3 +60,8 @@
 - name: Set up properties file
   include_tasks: "config.yml"
   when: base_version is defined
+
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/ohs/tasks/patch.yml
+++ b/roles/ohs/tasks/patch.yml
@@ -122,11 +122,3 @@
   args:
     chdir: "/tmp/{{ item.number }}"
   loop: "{{ patches }}"
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/OHS
-    - /tmp/repo.zip

--- a/roles/oracle/tasks/cleanup.yml
+++ b/roles/oracle/tasks/cleanup.yml
@@ -1,0 +1,43 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup base installer files
+  file:
+    path: "/tmp/{{ item }}"
+    state: absent
+  loop: "{{ base_installer if base_installer is iterable and base_installer is not string else [base_installer] }}"
+  when: base_installer is defined
+  ignore_errors: yes
+
+- name: Cleanup OracleInstaller directory
+  file:
+    path: /tmp/OracleInstaller
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup OPatch file
+  file:
+    path: "/tmp/{{ opatch_filename }}"
+    state: absent
+  when: opatch_filename is defined
+  ignore_errors: yes
+
+- name: Cleanup patch files
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/{{ patch_filename }}"
+    - "/tmp/{{ patch_number }}"
+  when: patch_filename is defined and patch_number is defined
+  ignore_errors: yes
+
+- name: Cleanup JDK patch files
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/{{ jdk_patch_filename }}"
+    - "/tmp/{{ jdk_patch_number }}"
+  when: jdk_patch_filename is defined and jdk_patch_number is defined
+  ignore_errors: yes

--- a/roles/oracle/tasks/jdkpatch.yml
+++ b/roles/oracle/tasks/jdkpatch.yml
@@ -60,11 +60,3 @@
   retries: 30
   delay: 30
   when: jdk_patch_applied.rc != 0
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/{{ jdk_patch_filename }}
-    - /tmp/{{ jdk_patch_number }}

--- a/roles/oracle/tasks/main.yml
+++ b/roles/oracle/tasks/main.yml
@@ -53,3 +53,8 @@
     regexp: '^(.*):N$'
     replace: '\1:Y'
     backup: yes
+
+- name: Cleanup installer files
+  include_tasks: "cleanup.yml"
+  tags:
+    - cleanup

--- a/roles/oracle/tasks/patch.yml
+++ b/roles/oracle/tasks/patch.yml
@@ -134,14 +134,6 @@
   delay: 30
   when: patch_applied.rc != 0
 
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/{{ patch_filename }}
-    - /tmp/{{ patch_number }}
-
 - name: Check listener status
   become: yes
   become_user: oracle

--- a/roles/weblogic/tasks/cleanup.yml
+++ b/roles/weblogic/tasks/cleanup.yml
@@ -1,0 +1,61 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup base installer file
+  file:
+    path: "{{ mw_installer_folder }}/{{ base_install_file }}"
+    state: absent
+  when: base_install_file is defined
+  ignore_errors: yes
+
+- name: Cleanup Java installer
+  file:
+    path: "{{ mw_installer_folder }}/java-repo.zip"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup OPatch file
+  file:
+    path: "{{ mw_installer_folder }}/{{ opatch }}"
+    state: absent
+  when: opatch is defined
+  ignore_errors: yes
+
+- name: Cleanup OPatch extracted directory
+  file:
+    path: "{{ mw_installer_folder }}/6880880"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup patch file
+  file:
+    path: "{{ mw_installer_folder }}/{{ weblogic_patch_path }}/{{ patch }}"
+    state: absent
+  when: patch is defined and weblogic_patch_path is defined
+  ignore_errors: yes
+
+- name: Cleanup extracted patch folder
+  file:
+    path: "{{ mw_installer_folder }}/{{ weblogic_patch_path }}/{{ patch_folder }}"
+    state: absent
+  when: patch_folder is defined and weblogic_patch_path is defined
+  ignore_errors: yes
+
+- name: Cleanup patch directory
+  file:
+    path: "{{ mw_installer_folder }}/patch"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup Patches directory
+  file:
+    path: "{{ mw_installer_folder }}/Patches"
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup entire weblogic patch path directory
+  file:
+    path: "{{ mw_installer_folder }}/{{ weblogic_patch_path }}"
+    state: absent
+  when: weblogic_patch_path is defined
+  ignore_errors: yes

--- a/roles/weblogic/tasks/main.yml
+++ b/roles/weblogic/tasks/main.yml
@@ -33,3 +33,8 @@
 
 - include_tasks: patch.yml
   when: (patch is defined) and (weblogic_version_status.rc != 0)
+
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/websphere/tasks/cleanup.yml
+++ b/roles/websphere/tasks/cleanup.yml
@@ -1,0 +1,14 @@
+---
+# Cleanup all installer files and extracted directories after installation
+
+- name: Cleanup repo-zips directory
+  file:
+    path: /tmp/repo-zips
+    state: absent
+  ignore_errors: yes
+
+- name: Cleanup repo directory
+  file:
+    path: /tmp/repo
+    state: absent
+  ignore_errors: yes

--- a/roles/websphere/tasks/fixpack_install.yml
+++ b/roles/websphere/tasks/fixpack_install.yml
@@ -38,11 +38,3 @@
     path: "{{ websphere_install_path }}"
     repo: /tmp/repo
     state: present
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/repo
-    - /tmp/repo-zips

--- a/roles/websphere/tasks/main.yml
+++ b/roles/websphere/tasks/main.yml
@@ -34,10 +34,7 @@
     mode: 0644
     force: no
 
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/repo
-    - /tmp/repo-zips
+- name: Cleanup installer files
+  include_tasks: cleanup.yml
+  tags:
+    - cleanup

--- a/roles/websphere/tasks/v85_base_install.yml
+++ b/roles/websphere/tasks/v85_base_install.yml
@@ -42,11 +42,3 @@
     repo: /tmp/repo
     state: present
   when: "iim_info.packages | select('match', 'com.ibm.websphere.ND.*') | list | length == 0"
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/repo
-    - /tmp/repo-zips

--- a/roles/websphere/tasks/v90_base_install.yml
+++ b/roles/websphere/tasks/v90_base_install.yml
@@ -79,11 +79,3 @@
     repo: "{{ repo_list }}"
     state: present
   when: "iim_info.packages | select('match', 'com.ibm.websphere.ND.*') | list | length == 0"
-
-- name: Cleanup
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /tmp/repo
-    - /tmp/repo-zips


### PR DESCRIPTION
Following the recent Oracle FixPacks - i noticed 1 of the VMs ran out of disk space in the /home directory when trying to deploy Curam

The main reason looked to be that the OHS, WLS and Oracle installers, patches etc were not cleaned up properly and remained on the file system.  Once cleaned up and removed manually - Curam could then deploy

This PR adds in a specific cleanup task for these Oracle roles.  I have also extended this to other roles for consistency and maintainability going forward.