### PR TITLE
Bump middleware versions and add var files for IBM Middleware

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.10.10
+version: 1.10.11
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ihs-v90/converge.yml
+++ b/molecule/__ihs-v90/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    ihs_version: 9.0.5.27
+    ihs_version: 9.0.5.28
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty/converge.yml
+++ b/molecule/__liberty/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "26.0.0.3"
+    liberty_version: "26.0.0.6"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__liberty21/converge.yml
+++ b/molecule/__liberty21/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    liberty_version: "26.0.0.3-JDK21"
+    liberty_version: "26.0.0.6-JDK21"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/molecule/__websphere-v90/converge.yml
+++ b/molecule/__websphere-v90/converge.yml
@@ -8,7 +8,7 @@
   vars:
     iim_agent_version: 1.10.1003.20250827_1041
     iim_install_path: /opt/IBM/InstallationManager
-    websphere_version: 9.0.5.27
+    websphere_version: 9.0.5.28
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 

--- a/roles/ihs/README.md
+++ b/roles/ihs/README.md
@@ -13,18 +13,18 @@ NOTE: ihs_admin_pass should be changed after first installation.
 | `ihs_install_path`      | `/opt/IBM/HTTPServer`                               |
 | `plg_install_path`      | `/opt/IBM/WebSphere/Plugins`                        |
 | `wct_install_path`      | `/opt/IBM/WebSphere/Toolbox`                        |
-| `ihs_version`           | `9.0.5.27`                                           |
+| `ihs_version`           | `9.0.5.28`                                           |
 | `ihs_config_type`       | `local_distributed`                                 |
 | `ihs_admin_user`        | `wasadmin`                                          |
 | `ihs_admin_pass`        | `wasadmin`                                          |
 | ----------------------- | --------------------------------------------------- |
-| Version-specific:       | Values from `9.0.5.27`                               |
+| Version-specific:       | Values from `9.0.5.28`                               |
 | ----------------------- | --------------------------------------------------- |x  
 | `ihs_installer_archive_list` | `was.repo.90500.[ihs|plugins|wct].zip`         |
 | `ihs_fp_installer_path` | `WAS/9.0.5Fixpacks`                                 |
-| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP027.zip`           |
-| `ihs_pid`               | `v90~9.0.5027.20260306_2357`                        |
-| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.60-linux-x64-installmgr.zip` |
+| `ihs_fp_installer_archive_list` | `9.0.5-WS-[IHSPLG|WCT]-FP028.zip`           |
+| `ihs_pid`               | `v90~9.0.5028.20260604_1356`                        |
+| `ihs_java_zip_path`     | `Java/IBM/ibm-java-sdk-8.0-8.65-linux-x64-installmgr.zip` |
 | `ihs_java_pid`          | `com.ibm.java.jdk.v8`                               |
 | ----------------------- | --------------------------------------------------- |
 | `iim_install_path`      | `/opt/IBM/InstallationManager`                      |
@@ -53,7 +53,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware.iim
     - merative.spm_middleware.ihs
       vars:
-        - ihs_version: 9.0.5.27
+        - ihs_version: 9.0.5.28
         - download_url: "https://myserver.com/IHS/repos"
         - download_header: { 'Authorization': 'Basic EncodedString'}
 ```

--- a/roles/ihs/defaults/main.yml
+++ b/roles/ihs/defaults/main.yml
@@ -5,7 +5,7 @@ ihs_install_path: /opt/IBM/HTTPServer
 plg_install_path: /opt/IBM/WebSphere/Plugins
 wct_install_path: /opt/IBM/WebSphere/Toolbox
 
-ihs_version: 9.0.5.27
+ihs_version: 9.0.5.28
 
 ihs_config_type: local_distributed
 ihs_admin_user: wasadmin

--- a/roles/ihs/vars/v9.0.5.28.yml
+++ b/roles/ihs/vars/v9.0.5.28.yml
@@ -1,0 +1,16 @@
+---
+ihs_installer_path: WAS/9.0.5ND
+ihs_installer_archive_list:
+  - was.repo.90500.ihs.zip
+  - was.repo.90500.plugins.zip
+  - was.repo.90500.wct.zip
+
+ihs_fp_installer_path: WAS/9.0.5Fixpacks
+ihs_fp_installer_archive_list:
+  - 9.0.5-WS-IHSPLG-FP028.zip
+  - 9.0.5-WS-WCT-FP028.zip
+
+ihs_pid: v90_9.0.5028.20260604_1356
+
+ihs_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.65-linux-x64-installmgr.zip
+ihs_java_pid: com.ibm.java.jdk.v8

--- a/roles/liberty/README.md
+++ b/roles/liberty/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) must already be installed in the target environ
 | Property Name           | Default value                                       |
 | ----------------------- | --------------------------------------------------- |
 | `liberty_install_path`  | `/opt/IBM/WebSphere/Liberty`                        |
-| `liberty_version`       | `26.0.0.3`                                         |
+| `liberty_version`       | `26.0.0.6`                                         |
 | `liberty_default_heapsize`  | `1024m`                                         |
 | `liberty_enable_verbose_gc` | `false`                                         |
 | `liberty_extra_jvm_options` | `[]`                                            |
@@ -37,7 +37,7 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.liberty
-      liberty_version: 26.0.0.3
+      liberty_version: 26.0.0.6
 ```
 
 ## License

--- a/roles/liberty/defaults/main.yml
+++ b/roles/liberty/defaults/main.yml
@@ -3,7 +3,7 @@ iim_install_path: /opt/IBM/InstallationManager
 
 liberty_install_path: /opt/IBM/WebSphere/Liberty
 
-liberty_version: 26.0.0.3
+liberty_version: 26.0.0.6
 
 jdk_version: 8.0
 

--- a/roles/liberty/vars/v26.0.0.6-JDK21.yml
+++ b/roles/liberty/vars/v26.0.0.6-JDK21.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/26.0.0.6-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 26.0.6.20260531_0302
+jdk_version: 21.0
+jdk_installation_way: unzip
+liberty_java_zip_path: Java/IBM/ibm-semeru-open-jdk_x64_linux_21.0.11.0.tar.gz

--- a/roles/liberty/vars/v26.0.0.6.yml
+++ b/roles/liberty/vars/v26.0.0.6.yml
@@ -1,0 +1,7 @@
+---
+liberty_fp_path: WLP/26.0.0.6-WS-LIBERTY-ND-FP.zip
+liberty_installers_path: WLP/was.repo.16002.liberty.nd.zip
+liberty_pid: 26.0.6.20260531_0302
+
+liberty_java_zip_path: Java/IBM/ibm-java-sdk-8.0-8.65-linux-x64-installmgr.zip
+liberty_java_pid: com.ibm.java.jdk.v8_8.0.8065.20260410_0653

--- a/roles/websphere/README.md
+++ b/roles/websphere/README.md
@@ -11,7 +11,7 @@ IBM Installation Manager (1.9.x) or higher must already be installed in the targ
 | Property Name            | Default value                                       |
 | ------------------------ | --------------------------------------------------- |
 | `websphere_install_path` | `/opt/IBM/WebSphere/AppServer`                      |
-| `websphere_version`      | `9.0.5.27`                                           |
+| `websphere_version`      | `9.0.5.28`                                           |
 | ------------------------ | --------------------------------------------------- |
 | `iim_install_path`       | `/opt/IBM/InstallationManager`                      |
 | `profiled_path`          | `/opt/profile.d`                                    |
@@ -35,7 +35,7 @@ merative.spm_middleware.iim
     - merative.spm_middleware
 
   vars:
-    websphere_version: 9.0.5.27
+    websphere_version: 9.0.5.28
     download_url: "https://myserver.com/was/repos"
     download_header: { 'Authorization': 'Basic EncodedString'}
 

--- a/roles/websphere/defaults/main.yml
+++ b/roles/websphere/defaults/main.yml
@@ -3,7 +3,7 @@
 iim_install_path: /opt/IBM/InstallationManager
 # websphere
 websphere_install_path: /opt/IBM/WebSphere/AppServer
-websphere_version: 9.0.5.27
+websphere_version: 9.0.5.28
 security_username: websphere
 # use encrypted password
 security_password: dummypassword

--- a/roles/websphere/vars/v9.0.5.28.yml
+++ b/roles/websphere/vars/v9.0.5.28.yml
@@ -1,0 +1,17 @@
+---
+# FP Vars
+websphere_pid: v90_9.0.5028.20260604_1356
+websphere_fp_path: WAS/9.0.5Fixpacks
+websphere_fp_archive_list:
+  - 9.0.5-WS-WAS-FP028.zip
+
+# Base Vars
+websphere_base_pid: com.ibm.websphere.ND.v90
+websphere_base_path: WAS/9.0.5ND
+websphere_base_archive_list:
+  - was.repo.90500.nd.zip
+
+# Java Vars
+websphere_java_path: Java/IBM/ibm-java-sdk-8.0-8.65-linux-x64-installmgr.zip
+websphere_java_pid: com.ibm.java.jdk.v8
+websphere_java_home: java/8.0


### PR DESCRIPTION
Update multiple middleware component versions and add corresponding variables files.

- Bumped collection version to 1.10.11 (galaxy.yml).
- IHS: upgraded to 9.0.5.28 (molecule, role defaults, README) and added roles/ihs/vars/v9.0.5.28.yml with installer lists, FP entries, PID and Java paths.
- Liberty: upgraded to 26.0.0.6 (molecule, role defaults, README) and added vars files roles/liberty/vars/v26.0.0.6.yml and roles/liberty/vars/v26.0.0.6-JDK21.yml containing FP/installers/PID and Java/JDK settings.
- WebSphere: upgraded to 9.0.5.28 (molecule, role defaults, README) and added roles/websphere/vars/v9.0.5.28.yml with base/FP/java installer details and PIDs.

These changes keep test scenarios and role defaults in sync with the new product releases and provide per-version variable files for deployment automation.