### PR TITLE
Update DB2 to 12.1.5.0 and IIM agent version

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
 # Please note. version also exists in /github/workflows/release.yml and will need to be update also
-version: 1.10.11
+version: 1.10.12
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__websphere-v90/converge.yml
+++ b/molecule/__websphere-v90/converge.yml
@@ -6,7 +6,7 @@
     - merative.spm_middleware
 
   vars:
-    iim_agent_version: 1.10.1003.20250827_1041
+    iim_agent_version: 1.10.1004.20260506_0701
     iim_install_path: /opt/IBM/InstallationManager
     websphere_version: 9.0.5.28
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"

--- a/molecule/db2-121/converge.yml
+++ b/molecule/db2-121/converge.yml
@@ -9,6 +9,6 @@
     - db2
 
   vars:
-    db2_version: "12.1.4.0"
+    db2_version: "12.1.5.0"
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}

--- a/molecule/db2-121/verify.yml
+++ b/molecule/db2-121/verify.yml
@@ -19,4 +19,4 @@
       assert:
         that:
           - db2level_cmd.rc == 0
-          - "'v12.1.4' in db2level_cmd.stdout"
+          - "'v12.1.5' in db2level_cmd.stdout"

--- a/roles/db2/README.md
+++ b/roles/db2/README.md
@@ -13,7 +13,7 @@ Ensure you update / override password variables prior to using the role.
 | Property Name             | Default value                                       |
 | ------------------------- | --------------------------------------------------- |
 | `db2_install_path`        | `/opt/IBM/db2`                                      |
-| `db2_version`             | `12.1.4.0`                                          |
+| `db2_version`             | `12.1.5.0`                                          |
 | `db2_product`             | `DB2_SERVER_EDITION`                                |
 | `db2_bypass_prereq_check` | `False`                                             |
 | ------------------------- | --------------------------------------------------- |
@@ -43,7 +43,7 @@ None
 - hosts: servers
   roles:
     - role: merative.spm_middleware.db2
-      db2_version: 12.1.4.0
+      db2_version: 12.1.5.0
 ```
 
 ## License

--- a/roles/db2/vars/v12.1.5.0.yml
+++ b/roles/db2/vars/v12.1.5.0.yml
@@ -1,0 +1,4 @@
+---
+# paths can be relative to download_url or local
+db2_installer_path: DB2/12.1/v12.1.5_linuxx64_universal_fixpack.tar.gz
+db2_license_path: DB2/12.1/db2ese_u.lic

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -30,7 +30,7 @@
     mode: 0755
     creates: "{{ tmp_dir.path }}/installc"
 
-- name: Run IIM installer
+- name: Run IIM installer for Installation Manager {{ iim_agent_version}}
   command:
     cmd: ./installc -acceptLicense -iD {{ iim_install_path }}
     chdir: "{{ tmp_dir.path }}"


### PR DESCRIPTION
Upgrade DB2 from 12.1.4.0 to 12.1.5.0 with new configuration variables. 
Update IIM agent version to 1.10.1004.20260506_0701 for WebSphere install and enhance installer task naming. 
Update collection version to 1.10.12 and refresh all related test configurations and documentation.